### PR TITLE
Added the new predicate "atTags"

### DIFF
--- a/src/main/java/io/prismic/Predicates.java
+++ b/src/main/java/io/prismic/Predicates.java
@@ -21,6 +21,10 @@ public class Predicates {
     return new SimplePredicate("at", fragment, value);
   }
 
+  public static Predicate atTags(Iterable<String> values) {
+    return new SimplePredicate("at", "document.tags", values);
+  }
+
   public static Predicate any(String fragment, Iterable<String> values) {
     return new SimplePredicate("any", fragment, values);
   }

--- a/src/test/java/io/prismic/PredicateTest.java
+++ b/src/test/java/io/prismic/PredicateTest.java
@@ -14,6 +14,12 @@ public class PredicateTest {
   }
 
   @Test
+  public void testAtTagsPredicate() throws Exception {
+    Predicate p = Predicates.atTags(Arrays.asList("Macaron", "Cupcakes"));
+    Assert.assertEquals("[:d = at(document.tags, [\"Macaron\",\"Cupcakes\"])]", p.q());
+  }
+
+  @Test
   public void testAnyPredicate() throws Exception {
     Predicate p = Predicates.any("document.tags", Arrays.asList("Macaron", "Cupcakes"));
     Assert.assertEquals("[:d = any(document.tags, [\"Macaron\",\"Cupcakes\"])]", p.q());


### PR DESCRIPTION
Added the new predicate "atTags", which takes an iterable of strings. The existing at-predicate implementation only accepts one string, which makes it unusable for tags.