### PR TITLE
Add http proxy support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,12 @@
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.littleshoot</groupId>
+            <artifactId>littleproxy</artifactId>
+            <version>1.0.0-beta8</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/src/main/java/io/prismic/Form.java
+++ b/src/main/java/io/prismic/Form.java
@@ -399,7 +399,7 @@ public class Form {
             sep = "&";
           }
         }
-        JsonNode json = HttpClient.fetch(url.toString(), api.getLogger(), api.getCache());
+        JsonNode json = HttpClient.fetch(url.toString(), api.getLogger(), api.getCache(), api.getProxy());
         return Response.parse(json);
       } else {
         throw new Api.Error(Api.Error.Code.UNEXPECTED, "Form type not supported");

--- a/src/main/java/io/prismic/Proxy.java
+++ b/src/main/java/io/prismic/Proxy.java
@@ -1,0 +1,19 @@
+package io.prismic;
+
+public class Proxy {
+  private final String host;
+  private final int port;
+
+  public Proxy(String host, int port) {
+    this.host = host;
+    this.port = port;
+  }
+
+  public String getHost() {
+    return host;
+  }
+
+  public int getPort() {
+    return port;
+  }
+}

--- a/src/main/java/io/prismic/core/HttpClient.java
+++ b/src/main/java/io/prismic/core/HttpClient.java
@@ -6,11 +6,14 @@ import java.net.*;
 import io.prismic.*;
 
 import com.fasterxml.jackson.databind.*;
+import io.prismic.Proxy;
 import org.apache.commons.io.IOUtils;
+
+import static java.net.Proxy.Type.HTTP;
 
 public class HttpClient {
 
-  public static JsonNode fetch(String url, Logger logger, Cache cache) {
+  public static JsonNode fetch(String url, Logger logger, Cache cache, Proxy proxy) {
     logger = (logger!=null) ? logger : new Logger.NoLogger();
     cache = (cache!=null) ? cache : new Cache.NoCache();
     try {
@@ -19,7 +22,14 @@ public class HttpClient {
         return cachedResult;
       }
 
-      URLConnection connection = new URL(url).openConnection();
+      URLConnection connection;
+      if (proxy != null) {
+        InetSocketAddress inetSocketAddress = new InetSocketAddress(proxy.getHost(), proxy.getPort());
+        java.net.Proxy javaProxy = new java.net.Proxy(HTTP, inetSocketAddress);
+        connection = new URL(url).openConnection(javaProxy);
+      } else {
+        connection = new URL(url).openConnection();
+      }
       HttpURLConnection httpConnection = (HttpURLConnection) connection;
       InputStream response = null;
 

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,0 +1,8 @@
+# Root logger option
+log4j.rootLogger=INFO, stdout
+
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n


### PR DESCRIPTION
- Add an optional proxy parameter to Api.get()
- Add a simple Proxy class containing proxy infos
- Modified HttpClient to handle proxy settings
