### PR TITLE
Add i18n support

### DIFF
--- a/src/main/java/io/prismic/Api.java
+++ b/src/main/java/io/prismic/Api.java
@@ -297,19 +297,33 @@ public class Api {
   }
 
   /**
+   * Start a query defaulting on the master reference (you can still override it) with the given language
+   */
+  public Form.SearchForm query(String lang, String q) {
+    String reference = this.defaultReference == null ? this.getMaster().getRef() : this.defaultReference;
+    return this.getForm("everything").ref(reference).lang(lang).query(q);
+  }
+
+  /**
    * Start a query defaulting on the master reference (you can still override it)
    */
   public Form.SearchForm query(String q) {
+    return this.query(null, q);
+  }
+
+  /**
+   * Start a query defaulting on the master reference (you can still override it) with the given language
+   */
+  public Form.SearchForm query(String lang, Predicate... predicates) {
     String reference = this.defaultReference == null ? this.getMaster().getRef() : this.defaultReference;
-    return this.getForm("everything").ref(reference).query(q);
+    return this.getForm("everything").ref(reference).lang(lang).query(predicates);
   }
 
   /**
    * Start a query defaulting on the master reference (you can still override it)
    */
   public Form.SearchForm query(Predicate... predicates) {
-    String reference = this.defaultReference == null ? this.getMaster().getRef() : this.defaultReference;
-    return this.getForm("everything").ref(reference).query(predicates);
+    return this.query(null, predicates);
   }
 
   /**
@@ -320,13 +334,13 @@ public class Api {
   }
 
   /**
-   * Return the first document matching the predicate
+   * Return the first document matching the predicate, language on the given reference
    */
-  public Document queryFirst(Predicate p, String ref) {
+  public Document queryFirst(Predicate p, String lang, String ref) {
     if (ref == null) {
       ref = this.defaultReference == null ? this.getMaster().getRef() : this.defaultReference;
     }
-    List<Document> results = query(p).ref(ref).submit().getResults();
+    List<Document> results = query(p).ref(ref).lang(lang).submit().getResults();
     if (results.size() > 0) {
       return results.get(0);
     } else {
@@ -334,8 +348,27 @@ public class Api {
     }
   }
 
+  /**
+   * Return the first document matching the predicate on the given reference
+   */
+  public Document queryFirst(Predicate p, String ref) {
+    return queryFirst(p, ref);
+  }
+
+  /**
+   * Return the first document matching the predicate on the master reference
+   */
   public Document queryFirst(Predicate p) {
-    return queryFirst(p, null);
+    return queryFirst(p, null, null);
+  }
+
+  /**
+   * Retrieve a document by its ID in the given language on the given reference
+   *
+   * @return the document, or null if it doesn't exist
+   */
+  public Document getByID(String documentId, String lang, String ref) {
+    return queryFirst(Predicates.at("document.id", documentId), lang, ref);
   }
 
   /**
@@ -344,7 +377,7 @@ public class Api {
    * @return the document, or null if it doesn't exist
    */
   public Document getByID(String documentId, String ref) {
-    return queryFirst(Predicates.at("document.id", documentId), ref);
+    return this.getByID(documentId, null, ref);
   }
 
   /**
@@ -362,7 +395,7 @@ public class Api {
    * @return the document, or null if it doesn't exist
    */
   public Document getByUID(String documentType, String documentUid, String ref) {
-    return queryFirst(Predicates.at("my." + documentType + ".uid", documentUid), ref);
+    return queryFirst(Predicates.at("my." + documentType + ".uid", documentUid), null, ref);
   }
 
   /**

--- a/src/main/java/io/prismic/Document.java
+++ b/src/main/java/io/prismic/Document.java
@@ -14,15 +14,19 @@ public class Document extends WithFragments {
   private final Set<String> tags;
   private final List<String> slugs;
   private final String type;
+  private final String lang;
+  private final List<String> alternateLanguages;
   private final Map<String, Fragment> fragments;
 
-  public Document(String id, String uid, String type, String href, Set<String> tags, List<String> slugs, Map<String,Fragment> fragments) {
+  public Document(String id, String uid, String type, String href, Set<String> tags, List<String> slugs, String lang, List<String> alternateLanguages, Map<String,Fragment> fragments) {
     this.id = id;
     this.uid = uid;
     this.type = type;
     this.href = href;
     this.tags = Collections.unmodifiableSet(tags);
     this.slugs = Collections.unmodifiableList(slugs);
+    this.lang = lang;
+    this.alternateLanguages = Collections.unmodifiableList(alternateLanguages);
     this.fragments = Collections.unmodifiableMap(fragments);
   }
 
@@ -57,6 +61,14 @@ public class Document extends WithFragments {
     return null;
   }
 
+  public String getLang() {
+    return lang;
+  }
+
+  public List<String> getAlternateLanguages() {
+    return alternateLanguages;
+  }
+
   @Override
   public Map<String, Fragment> getFragments() {
     return fragments;
@@ -75,7 +87,7 @@ public class Document extends WithFragments {
   }
 
   public Fragment.DocumentLink asDocumentLink() {
-    return new Fragment.DocumentLink(id, uid, type, tags, getSlug(), fragments, false);
+    return new Fragment.DocumentLink(id, uid, type, tags, getSlug(), lang, fragments, false);
   }
 
   // --
@@ -166,7 +178,13 @@ public class Document extends WithFragments {
     String uid = json.has("uid") ? json.path("uid").asText() : null;
     String href = json.path("href").asText();
     String type = json.path("type").asText();
+    String lang = json.path("lang").asText();
 
+    Iterator<JsonNode> alternateLanguagesJson = json.withArray("alternate_languages").elements();
+    List<String> alternateLanguages = new ArrayList<String>();
+    while(alternateLanguagesJson.hasNext()) {
+      alternateLanguages.add(alternateLanguagesJson.next().asText());
+    }
 
     Iterator<JsonNode> tagsJson = json.withArray("tags").elements();
     Set<String> tags = new HashSet<String>();
@@ -187,7 +205,7 @@ public class Document extends WithFragments {
 
     Map<String, Fragment> fragments = parseFragments(json.with("data").with(type), type);
 
-    return new Document(id, uid, type, href, tags, slugs, fragments);
+    return new Document(id, uid, type, href, tags, slugs, lang, alternateLanguages, fragments);
   }
 
 }

--- a/src/main/java/io/prismic/Form.java
+++ b/src/main/java/io/prismic/Form.java
@@ -193,6 +193,16 @@ public class Form {
     }
 
     /**
+     * Allows to set the language you want to get for your query.
+     *
+     * @param lang the language code you wish
+     * @return the current form, in order to chain those calls
+     */
+    public SearchForm lang(String lang) {
+      return set("lang", lang != null ? lang : "*");
+    }
+
+    /**
      * Allows to set the ref on which you wish to be performing the query.
      *
      * This is mandatory to submit a query; if you call <code>api.getForm("everything").submit();</code>, the kit will complain!

--- a/src/main/java/io/prismic/Fragment.java
+++ b/src/main/java/io/prismic/Fragment.java
@@ -448,6 +448,7 @@ public interface Fragment {
     private final String type;
     private final Set<String> tags;
     private final String slug;
+    private final String lang;
     private final boolean broken;
     private final Map<String, Fragment> fragments;
 
@@ -456,6 +457,7 @@ public interface Fragment {
                         String type,
                         Set<String> tags,
                         String slug,
+                        String lang,
                         Map<String, Fragment> fragments,
                         boolean broken) {
       this.id = id;
@@ -463,6 +465,7 @@ public interface Fragment {
       this.type = type;
       this.tags = tags;
       this.slug = slug;
+      this.lang = lang;
       this.fragments = fragments;
       this.broken = broken;
     }
@@ -513,12 +516,13 @@ public interface Fragment {
       String uid = document.path("uid").asText();
       String type = document.path("type").asText();
       String slug = document.path("slug").asText();
+      String lang = document.path("lang").asText();
       Set<String> tags = new HashSet<String>();
       for(JsonNode tagJson: document.withArray("tags")) {
         tags.add(tagJson.asText());
       }
       Map<String, Fragment> fragments = Document.parseFragments(document.with("data").with(type), type);
-      return new DocumentLink(id, uid, type, tags, slug, fragments, broken);
+      return new DocumentLink(id, uid, type, tags, slug, lang, fragments, broken);
     }
 
   }

--- a/src/test/java/io/prismic/DocumentTest.java
+++ b/src/test/java/io/prismic/DocumentTest.java
@@ -56,6 +56,22 @@ public class DocumentTest {
   }
 
   @Test
+  public void testParseLanguage() throws Exception {
+    JsonNode node = getJson("/fixtures/language.json");
+    Document doc = Document.parse(node);
+
+    Assert.assertEquals(
+      "de-ch",
+      doc.getLang()
+    );
+
+    Assert.assertEquals(
+      2,
+      doc.getAlternateLanguages().size()
+    );
+  }
+
+  @Test
   public void image() {
     Api api = Api.get("https://test-public.prismic.io/api");
     Document doc =

--- a/src/test/resources/fixtures/document_store.json
+++ b/src/test/resources/fixtures/document_store.json
@@ -1,5 +1,5 @@
 {
-    "id": "UlfoxUnM0wkXYXbb", "type": "store", "href": "https://lesbonneschoses.prismic.io/api/documents/search?ref=UlfoxUnM08QWYXdl&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22UlfoxUnM0wkXYXbb%22%29+%5D%5D", "tags": [], "slugs": ["paris-saint-lazare"], "linked_documents": [], "data": {
+    "id": "UlfoxUnM0wkXYXbb", "type": "store", "href": "https://lesbonneschoses.prismic.io/api/documents/search?ref=UlfoxUnM08QWYXdl&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22UlfoxUnM0wkXYXbb%22%29+%5D%5D", "tags": [], "slugs": ["paris-saint-lazare"], "lang": "fr-fr", "alternate_languages":[], "linked_documents": [], "data": {
     "store": {
         "name": {
             "type": "StructuredText",

--- a/src/test/resources/fixtures/language.json
+++ b/src/test/resources/fixtures/language.json
@@ -1,0 +1,14 @@
+{
+    "id":"VQ_hV31Za5EAy02H",
+    "uid":null,
+    "type":"article",
+    "href":"http://toto.wroom.dev/api/documents/search?ref=VQ_uWX1Za0oCy46m&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22VQ_hV31Za5EAy02H%22%29+%5D%5D",
+    "tags":[],
+    "slugs":["schweizer-deutsch"],
+    "lang":"de-ch",
+    "alternate_languages":["fr-fr","en-gb"],
+    "linked_documents":[],
+    "data":{
+        "article":{}
+    }
+}

--- a/src/test/resources/fixtures/slices.json
+++ b/src/test/resources/fixtures/slices.json
@@ -5,6 +5,8 @@
     "href":"http://toto.wroom.dev/api/documents/search?ref=VQ_uWX1Za0oCy46m&q=%5B%5B%3Ad+%3D+at%28document.id%2C+%22VQ_hV31Za5EAy02H%22%29+%5D%5D",
     "tags":[],
     "slugs":["une-activite"],
+    "lang":"fr-fr",
+    "alternate_languages":[],
     "linked_documents":[],
     "data":{
         "article":{


### PR DESCRIPTION
This pr adds i18n support and does it in a very similar way as it was done in the javascript-kit before.

* The `lang` and `alternate_languages` fields are parsed and saved
* The new `Form.lang(String lang)` method allows you to filter for a language
* The following new `Api` query methods are added
  * `Form.SearchForm Api.query(String lang, String q)`
  * `Form.SearchForm Api.query(String lang, Predicate... predicates)`
  * `Document  Api.queryFirst(Predicate p, String lang, String ref)`
  * `Document  Api.getByID(String documentId, String lang, String ref)`

This change should not break the existing api.
