### PR TITLE
Fix support for i18n alternate languages

### DIFF
--- a/src/main/java/io/prismic/AlternateLanguage.java
+++ b/src/main/java/io/prismic/AlternateLanguage.java
@@ -1,0 +1,32 @@
+package io.prismic;
+
+public class AlternateLanguage {
+  
+  private final String id;
+  private final String uid;
+  private final String type;
+  private final String lang;
+
+  public AlternateLanguage(String id, String uid, String type, String lang) {
+    this.id = id;
+    this.uid = uid;
+    this.type = type;
+    this.lang = lang;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getUid() {
+    return uid;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public String getLang() {
+    return lang;
+  }
+}

--- a/src/main/java/io/prismic/Document.java
+++ b/src/main/java/io/prismic/Document.java
@@ -17,12 +17,12 @@ public class Document extends WithFragments {
   private final List<String> slugs;
   private final String type;
   private final String lang;
-  private final List<String> alternateLanguages;
+  private final List<AlternateLanguage> alternateLanguages;
   private final DateTime firstPublicationDate;
   private final DateTime lastPublicationDate;
   private final Map<String, Fragment> fragments;
 
-  public Document(String id, String uid, String type, String href, Set<String> tags, List<String> slugs, String lang, List<String> alternateLanguages, DateTime firstPublicationDate, DateTime lastPublicationDate, Map<String,Fragment> fragments) {
+  public Document(String id, String uid, String type, String href, Set<String> tags, List<String> slugs, String lang, List<AlternateLanguage> alternateLanguages, DateTime firstPublicationDate, DateTime lastPublicationDate, Map<String,Fragment> fragments) {
     this.id = id;
     this.uid = uid;
     this.type = type;
@@ -71,7 +71,7 @@ public class Document extends WithFragments {
     return lang;
   }
 
-  public List<String> getAlternateLanguages() {
+  public List<AlternateLanguage> getAlternateLanguages() {
     return alternateLanguages;
   }
 
@@ -197,9 +197,14 @@ public class Document extends WithFragments {
     DateTime lastPublicationDate = parseDateTime(json.path("last_publication_date"));
 
     Iterator<JsonNode> alternateLanguagesJson = json.withArray("alternate_languages").elements();
-    List<String> alternateLanguages = new ArrayList<String>();
+    List<AlternateLanguage> alternateLanguages = new ArrayList<AlternateLanguage>();
     while(alternateLanguagesJson.hasNext()) {
-      alternateLanguages.add(alternateLanguagesJson.next().asText());
+      JsonNode altLangJson = alternateLanguagesJson.next();
+      String altLangId = altLangJson.path("id").asText();
+      String altLangUid = altLangJson.has("uid") ? altLangJson.path("uid").asText() : null;
+      String altLangType = altLangJson.path("type").asText();
+      String altLangCode = altLangJson.path("lang").asText();
+      alternateLanguages.add(new AlternateLanguage(altLangId, altLangUid, altLangType, altLangCode));
     }
 
     Iterator<JsonNode> tagsJson = json.withArray("tags").elements();

--- a/src/test/java/io/prismic/DocumentTest.java
+++ b/src/test/java/io/prismic/DocumentTest.java
@@ -114,8 +114,8 @@ public class DocumentTest {
     );
 
     Assert.assertEquals(
-      2,
-      doc.getAlternateLanguages().size()
+      "french",
+      doc.getAlternateLanguages().get(0).getUid()
     );
   }
 

--- a/src/test/resources/fixtures/language.json
+++ b/src/test/resources/fixtures/language.json
@@ -6,7 +6,19 @@
     "tags":[],
     "slugs":["schweizer-deutsch"],
     "lang":"de-ch",
-    "alternate_languages":["fr-fr","en-gb"],
+    "alternate_languages":[
+      {
+        "id": "WZ1iGioAACkA7Kqn",
+        "uid": "french",
+        "type": "article",
+        "lang": "fr-fr"
+      },{
+        "id": "WZ1iPyoAACkA7KtJ",
+        "uid": "spanish",
+        "type": "article",
+        "lang": "es-es"
+      }
+    ],
     "linked_documents":[],
     "first_publication_date": "2017-01-13T11:45:21.000Z",
     "last_publication_date": "2017-02-21T16:05:19.000Z",


### PR DESCRIPTION
This update does the following

- Adds an AlternateLanguages class
- Updates the document's alternateLanguage property to be a List of AlternateLanguages
- Updates the tests for the getAlternateLanguages function