### PR TITLE
[bug] Fix Travis build which does not work anymore with oraclejdk7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: java
 
 jdk:
+  - openjdk7
+  - openjdk8
   - oraclejdk8
-  - oraclejdk7
 
 sudo: false


### PR DESCRIPTION
Hello team!

`oraclejdk7` does not exists anymore on Travis trusty dist (see https://github.com/travis-ci/travis-ci/issues/7884), so new builds are failing (_e.g._ https://travis-ci.org/damienbeaufils/java-kit/builds/282128341). 
This PR change Travis config to remove `oraclejdk7` and use OpenJDK instead.

Thanks and happy hacktoberfest!