### PR TITLE
[bug] Image alt attribute should be "" instead of "null" when empty alternative text in CMS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: java
 
 jdk:
+  - openjdk7
+  - openjdk8
   - oraclejdk8
-  - oraclejdk7
 
 sudo: false

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.prismic</groupId>
     <artifactId>java-kit</artifactId>
     <packaging>jar</packaging>
-    <version>1.6.1</version>
+    <version>1.6.2-SNAPSHOT</version>
     <name>java-kit</name>
     <description>The developer kit to access Prismic.io repositories using the Java language.</description>
     <url>http://maven.apache.org</url>

--- a/src/main/java/io/prismic/Fragment.java
+++ b/src/main/java/io/prismic/Fragment.java
@@ -580,7 +580,10 @@ public interface Fragment {
       }
 
       public String asHtml(LinkResolver linkResolver) {
-        String imgTag = "<img alt=\"" + alt + "\" src=\"" + url + "\" width=\"" + width + "\" height=\"" + height + "\" />";
+        String imgTag = "<img alt=\"";
+        if (alt != null && !alt.equals("null")) imgTag += alt;
+        imgTag += "\" src=\"" + url + "\" width=\"" + width + "\" height=\"" + height + "\" />";
+
         if (this.linkTo != null) {
           String url = "about:blank";
           if (this.linkTo instanceof WebLink) {

--- a/src/main/java/io/prismic/Fragment.java
+++ b/src/main/java/io/prismic/Fragment.java
@@ -701,7 +701,7 @@ public interface Fragment {
 
     public String asHtml(LinkResolver linkResolver) {
       String className = "slice";
-      if (this.label != null && this.label != "null") className += (" " + this.label);
+      if (this.label != null && !this.label.equals("null")) className += (" " + this.label);
       List<GroupDoc> groupDocs = new ArrayList<GroupDoc>(Arrays.asList(this.nonRepeat));
       Group nonRepeat = this.nonRepeat != null ? new Group(groupDocs) : null;
       return "<div data-slicetype=\"" + this.sliceType + "\" class=\"" + className + "\">" +
@@ -743,7 +743,7 @@ public interface Fragment {
 
     public String asHtml(LinkResolver linkResolver) {
       String className = "slice";
-      if (this.label != null && this.label != "null") className += (" " + this.label);
+      if (this.label != null && !this.label.equals("null")) className += (" " + this.label);
       return "<div data-slicetype=\"" + this.sliceType + "\" class=\"" + className + "\">" +
         WithFragments.fragmentHtml(this.value, linkResolver, null) +
         "</div>";

--- a/src/test/java/io/prismic/DocumentTest.java
+++ b/src/test/java/io/prismic/DocumentTest.java
@@ -92,14 +92,14 @@ public class DocumentTest {
       "The composite slices retrieval works well",
       doc.getSliceZone("page.page_content")
     );
-    
+
     Assert.assertEquals(
       "The composite slices HTML serialization works well",
       doc.getSliceZone("page.page_content").asHtml(linkResolver),
       "<div data-slicetype=\"text\" class=\"slice levi-label\"><section data-field=\"rich_text\"><p>Here is paragraph 1.</p><p>Here is paragraph 2.</p></section></div>"
       + "<div data-slicetype=\"image_gallery\" class=\"slice\"><section data-field=\"gallery_title\"><h2>Image Gallery</h2></section>"
-      + "<section data-field=\"image\"><img alt=\"null\" src=\"https://prismic-io.s3.amazonaws.com/levi-templeting%2Fdc0bfab3-d222-44a6-82b8-c74f8cdc6a6b_200_s.gif\" width=\"267\" height=\"200\" /></section>"
-      + "<section data-field=\"image\"><img alt=\"null\" src=\"https://prismic-io.s3.amazonaws.com/levi-templeting/83c03dac4a604ac2e97e285e60034c641abd73b6_image2.jpg\" width=\"400\" height=\"369\" /></section></div>"
+      + "<section data-field=\"image\"><img alt=\"\" src=\"https://prismic-io.s3.amazonaws.com/levi-templeting%2Fdc0bfab3-d222-44a6-82b8-c74f8cdc6a6b_200_s.gif\" width=\"267\" height=\"200\" /></section>"
+      + "<section data-field=\"image\"><img alt=\"\" src=\"https://prismic-io.s3.amazonaws.com/levi-templeting/83c03dac4a604ac2e97e285e60034c641abd73b6_image2.jpg\" width=\"400\" height=\"369\" /></section></div>"
     );
   }
 


### PR DESCRIPTION
Hello team!

When you have an image in Prismic, if there is no alternative text, the `alt` attribute built from `Fragment.Image#asHtml` method is the string `"null"` instead of an empty string.
This PR fix this behavior: when the alternative text is empty, image alt attribute is now `""`.

> Omitting 'alt' attribute altogether indicates that the image is a key part of the content, and no textual equivalent is available. Setting this attribute to an empty string (alt="") indicates that this image is not a key part of the content, and that non-visual browsers may omit it from rendering. 
(see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img)

This PR depends on #56 

Thanks and happy hacktoberfest!
