### PR TITLE
[bug] SLF4J multiple bindings error when adding java-kit dependency in a new Spring Boot project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: java
 
 jdk:
+  - openjdk7
+  - openjdk8
   - oraclejdk8
-  - oraclejdk7
 
 sudo: false

--- a/pom.xml
+++ b/pom.xml
@@ -145,9 +145,9 @@
             <version>2.4</version>
         </dependency>
         <dependency>
-	          <groupId>javax.servlet</groupId>
-	          <artifactId>javax.servlet-api</artifactId>
-	          <version>3.0.1</version>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>3.0.1</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -156,18 +156,17 @@
             <scope>test</scope>
         </dependency>
         <!-- to simulate a proxy -->
-		<dependency>
-			<groupId>org.littleshoot</groupId>
-			<artifactId>littleproxy</artifactId>
-			<version>1.1.0</version>
-		</dependency>
-
-		<!--looger -->
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>1.7.25</version>
-		</dependency>
+        <dependency>
+          <groupId>org.littleshoot</groupId>
+          <artifactId>littleproxy</artifactId>
+          <version>1.1.0</version>
+        </dependency>
+        <!--logger -->
+        <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+          <version>1.7.25</version>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -164,14 +164,9 @@
 
 		<!--looger -->
 		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>1.2.17</version>
-		</dependency>
-		<dependency>
 			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.7.24</version>
+			<artifactId>slf4j-api</artifactId>
+			<version>1.7.25</version>
 		</dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.prismic</groupId>
     <artifactId>java-kit</artifactId>
     <packaging>jar</packaging>
-    <version>1.6.1</version>
+    <version>1.6.2-SNAPSHOT</version>
     <name>java-kit</name>
     <description>The developer kit to access Prismic.io repositories using the Java language.</description>
     <url>http://maven.apache.org</url>

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,8 +1,0 @@
-# Root logger option
-log4j.rootLogger=INFO, stdout
-
-# Direct log messages to stdout
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.Target=System.out
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n


### PR DESCRIPTION
Hello team!

If you create a new Spring Boot project (using [start.spring.io](https://start.spring.io/) for example) and add `java-kit` dependency, the application won't start because of a SLF4J binding error:
```
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Detected both log4j-over-slf4j.jar AND bound slf4j-log4j12.jar on the class path, preempting StackOverflowError. 
SLF4J: See also http://www.slf4j.org/codes.html#log4jDelegationLoop for more details.
Exception in thread "main" java.lang.ExceptionInInitializerError
        at org.slf4j.impl.StaticLoggerBinder.<init>(StaticLoggerBinder.java:72)
        at org.slf4j.impl.StaticLoggerBinder.<clinit>(StaticLoggerBinder.java:45)
        at org.slf4j.LoggerFactory.bind(LoggerFactory.java:150)
        at org.slf4j.LoggerFactory.performInitialization(LoggerFactory.java:124)
        at org.slf4j.LoggerFactory.getILoggerFactory(LoggerFactory.java:412)
        at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:357)
        at org.apache.commons.logging.LogFactory$Slf4jDelegate.createLocationAwareLog(LogFactory.java:174)
        at org.apache.commons.logging.LogFactory.getLog(LogFactory.java:111)
        at org.apache.commons.logging.LogFactory.getLog(LogFactory.java:99)
        at org.springframework.boot.SpringApplication.<clinit>(SpringApplication.java:198)
)
Caused by: java.lang.IllegalStateException: Detected both log4j-over-slf4j.jar AND bound slf4j-log4j12.jar on the class path, preempting StackOverflowError. See also http://www.slf4j.org/codes.html#log4jDelegationLoop for more details.
        at org.slf4j.impl.Log4jLoggerFactory.<clinit>(Log4jLoggerFactory.java:54)
        ... 11 more
```
It fails because `java-kit` has a dependency on `slf4j-log4j12`. The library should only use the SLF4J API without a specific binding (the project should choose the logger binding to use). More information on SLF4J and bindings [here](https://www.slf4j.org/images/concrete-bindings.png).

This PR fix this error by replacing `slf4j-log4j12` and `log4j` dependencies by the simple `slf4j-api` dependency.

This PR depends on #56 

Thanks and happy hacktoberfest!