### PR TITLE
[enhancement] Exposes DocumentLink's lang field

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: java
 
 jdk:
+  - openjdk7
+  - openjdk8
   - oraclejdk8
-  - oraclejdk7
 
 sudo: false

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.prismic</groupId>
     <artifactId>java-kit</artifactId>
     <packaging>jar</packaging>
-    <version>1.6.1</version>
+    <version>1.6.2-SNAPSHOT</version>
     <name>java-kit</name>
     <description>The developer kit to access Prismic.io repositories using the Java language.</description>
     <url>http://maven.apache.org</url>

--- a/src/main/java/io/prismic/Fragment.java
+++ b/src/main/java/io/prismic/Fragment.java
@@ -494,6 +494,10 @@ public interface Fragment {
       return slug;
     }
 
+    public String getLang() {
+      return lang;
+    }
+
     public boolean isBroken() {
       return broken;
     }


### PR DESCRIPTION
Hello team!

We need the lang field of `DocumentLink` to build an url in our `LinkResolver`.

We had to use reflection to expose this field:

```
public class PrismicLinkResolver extends SimpleLinkResolver {

    @Override
    public String resolve(DocumentLink link) {
        String lang = getLang(link);
        String type = link.getType();
        String uid = link.getUid();

        return "/" + lang + "/" + type + "/" + uid;
    }

    private String getLang(DocumentLink link) {
        try {
            Field field = ReflectionUtils.findField(DocumentLink.class, "lang", String.class);
            field.setAccessible(true);
            return (String) field.get(link);
        } catch (IllegalAccessException e) {
            throw new RuntimeException(e);
        }
    }
}
```

We would prefer a simple lang getter, instead of using reflection.
This PR exposes DocumentLink's lang field.

This PR depends on #56 

Thanks and happy hacktoberfest!