### PR TITLE
Add Support for Target Blank

### DIFF
--- a/src/main/java/io/prismic/Fragment.java
+++ b/src/main/java/io/prismic/Fragment.java
@@ -309,15 +309,23 @@ public interface Fragment {
      * @return target URL of the link
      */
     public String getUrl(LinkResolver resolver);
+    
+    /**
+     * Return the target of the link.
+     * @return target of the link
+     */
+    public String getTarget();
   }
 
   public static class WebLink implements Link {
     private final String url;
     private final String contentType;
+    private final String target;
 
-    public WebLink(String url, String contentType) {
+    public WebLink(String url, String contentType, String target) {
       this.url = url;
       this.contentType = contentType;
+      this.target = target;
     }
 
     /**
@@ -340,6 +348,10 @@ public interface Fragment {
       return contentType;
     }
 
+    public String getTarget() {
+      return target;
+    }
+
     public String asHtml() {
       return ("<a href=\"" + url + "\">" + url + "</a>");
     }
@@ -348,7 +360,8 @@ public interface Fragment {
 
     public static WebLink parse(JsonNode json) {
       String url = json.path("url").asText();
-      return new WebLink(url, null);
+      String target = json.has("target") ? json.path("target").asText() : null;
+      return new WebLink(url, null, target);
     }
   }
 
@@ -396,6 +409,10 @@ public interface Fragment {
       return filename;
     }
 
+    public String getTarget() {
+      return null;
+    }
+
     public String asHtml() {
       return ("<a href=\"" + url + "\">" + filename + "</a>");
     }
@@ -425,6 +442,10 @@ public interface Fragment {
 
     public String getUrl() {
       return url;
+    }
+
+    public String getTarget() {
+      return null;
     }
 
     public String asHtml() {
@@ -496,6 +517,10 @@ public interface Fragment {
 
     public String getLang() {
       return lang;
+    }
+
+    public String getTarget() {
+      return null;
     }
 
     public boolean isBroken() {
@@ -590,8 +615,11 @@ public interface Fragment {
 
         if (this.linkTo != null) {
           String url = "about:blank";
+          String target = "";
           if (this.linkTo instanceof WebLink) {
             url = ((WebLink) this.linkTo).getUrl();
+            String webTarget = ((WebLink) this.linkTo).getTarget();
+            target = webTarget != null ? " target=\"" + webTarget + "\" rel=\"noopener\"" : "";
           } else if (this.linkTo instanceof ImageLink) {
             url = ((ImageLink) this.linkTo).getUrl();
           } else if (this.linkTo instanceof DocumentLink) {
@@ -599,7 +627,7 @@ public interface Fragment {
               ? "#broken"
               : linkResolver.resolve((DocumentLink) this.linkTo);
           }
-          return "<a href=\"" + url + "\">" + imgTag + "</a>";
+          return "<a href=\"" + url + "\"" + target + ">" + imgTag + "</a>";
         } else {
           return imgTag;
         }
@@ -1260,7 +1288,8 @@ public interface Fragment {
         Span.Hyperlink hyperlink = (Span.Hyperlink)span;
         if(hyperlink.link instanceof WebLink) {
           WebLink webLink = (WebLink)hyperlink.getLink();
-          return "<a href=\""+ webLink.getUrl() + "\">" + content + "</a>";
+          String target = webLink.getTarget() != null ? " target=\"" + webLink.getTarget() + "\" rel=\"noopener\"" : "";
+          return "<a href=\""+ webLink.getUrl() + "\"" + target + ">" + content + "</a>";
         }
         else if(hyperlink.link instanceof FileLink) {
           FileLink fileLink = (FileLink)hyperlink.getLink();

--- a/src/test/java/io/prismic/DocumentTest.java
+++ b/src/test/java/io/prismic/DocumentTest.java
@@ -207,11 +207,11 @@ public class DocumentTest {
   @Test
   public void linksInImages() throws Exception {
     ObjectMapper mapper = new ObjectMapper();
-    String jsonString = "{ \"type\": \"StructuredText\", \"value\": [ { \"spans\": [], \"text\": \"Here is some introductory text.\", \"type\": \"paragraph\" }, { \"spans\": [], \"text\": \"The following image is linked.\", \"type\": \"paragraph\" }, { \"alt\": \"\", \"copyright\": \"\", \"dimensions\": { \"height\": 129, \"width\": 260 }, \"linkTo\": { \"type\": \"Link.web\", \"value\": { \"url\": \"http://google.com/\" } }, \"type\": \"image\", \"url\": \"http://fpoimg.com/129x260\" }, { \"spans\": [ { \"end\": 20, \"start\": 0, \"type\": \"strong\" } ], \"text\": \"More important stuff\", \"type\": \"paragraph\" }, { \"spans\": [], \"text\": \"The next is linked to a valid document:\", \"type\": \"paragraph\" }, { \"alt\": \"\", \"copyright\": \"\", \"dimensions\": { \"height\": 400, \"width\": 400 }, \"linkTo\": { \"type\": \"Link.document\", \"value\": { \"document\": { \"id\": \"UxCQFFFFFFFaaYAH\", \"slug\": \"something-fantastic\", \"type\": \"lovely-thing\" }, \"isBroken\": false } }, \"type\": \"image\", \"url\": \"http://fpoimg.com/400x400\" }, { \"spans\": [], \"text\": \"The next is linked to a broken document:\", \"type\": \"paragraph\" }, { \"alt\": \"\", \"copyright\": \"\", \"dimensions\": { \"height\": 250, \"width\": 250 }, \"linkTo\": { \"type\": \"Link.document\", \"value\": { \"document\": { \"id\": \"UxERPAEAAHQcsBUH\", \"slug\": \"-\", \"type\": \"event-calendar\" }, \"isBroken\": true } }, \"type\": \"image\", \"url\": \"http://fpoimg.com/250x250\" }, { \"spans\": [], \"text\": \"One more image, this one is not linked:\", \"type\": \"paragraph\" }, { \"alt\": \"\", \"copyright\": \"\", \"dimensions\": { \"height\": 199, \"width\": 300 }, \"type\": \"image\", \"url\": \"http://fpoimg.com/199x300\" } ] }";
+    String jsonString = "{ \"type\": \"StructuredText\", \"value\": [ { \"spans\": [], \"text\": \"Here is some introductory text.\", \"type\": \"paragraph\" }, { \"spans\": [], \"text\": \"The following image is linked.\", \"type\": \"paragraph\" }, { \"alt\": \"\", \"copyright\": \"\", \"dimensions\": { \"height\": 129, \"width\": 260 }, \"linkTo\": { \"type\": \"Link.web\", \"value\": { \"url\": \"http://google.com/\" } }, \"type\": \"image\", \"url\": \"http://fpoimg.com/129x260\" }, { \"spans\": [], \"text\": \"The following image is linked with a target blank.\", \"type\": \"paragraph\" }, { \"alt\": \"\", \"copyright\": \"\", \"dimensions\": { \"height\": 129, \"width\": 260 }, \"linkTo\": { \"type\": \"Link.web\", \"value\": { \"url\": \"http://google.com/\", \"target\": \"_blank\" } }, \"type\": \"image\", \"url\": \"http://fpoimg.com/129x260\" }, { \"spans\": [ { \"end\": 20, \"start\": 0, \"type\": \"strong\" } ], \"text\": \"More important stuff\", \"type\": \"paragraph\" }, { \"spans\": [], \"text\": \"The next is linked to a valid document:\", \"type\": \"paragraph\" }, { \"alt\": \"\", \"copyright\": \"\", \"dimensions\": { \"height\": 400, \"width\": 400 }, \"linkTo\": { \"type\": \"Link.document\", \"value\": { \"document\": { \"id\": \"UxCQFFFFFFFaaYAH\", \"slug\": \"something-fantastic\", \"type\": \"lovely-thing\" }, \"isBroken\": false } }, \"type\": \"image\", \"url\": \"http://fpoimg.com/400x400\" }, { \"spans\": [], \"text\": \"The next is linked to a broken document:\", \"type\": \"paragraph\" }, { \"alt\": \"\", \"copyright\": \"\", \"dimensions\": { \"height\": 250, \"width\": 250 }, \"linkTo\": { \"type\": \"Link.document\", \"value\": { \"document\": { \"id\": \"UxERPAEAAHQcsBUH\", \"slug\": \"-\", \"type\": \"event-calendar\" }, \"isBroken\": true } }, \"type\": \"image\", \"url\": \"http://fpoimg.com/250x250\" }, { \"spans\": [], \"text\": \"One more image, this one is not linked:\", \"type\": \"paragraph\" }, { \"alt\": \"\", \"copyright\": \"\", \"dimensions\": { \"height\": 199, \"width\": 300 }, \"type\": \"image\", \"url\": \"http://fpoimg.com/199x300\" } ] }";
     JsonNode json = mapper.readTree(jsonString);
     Fragment.StructuredText text = Fragment.StructuredText.parse(json.path("value"));
     Assert.assertEquals(
-      "<p>Here is some introductory text.</p><p>The following image is linked.</p><p class=\"block-img\"><a href=\"http://google.com/\"><img alt=\"\" src=\"http://fpoimg.com/129x260\" width=\"260\" height=\"129\" /></a></p><p><strong>More important stuff</strong></p><p>The next is linked to a valid document:</p><p class=\"block-img\"><a href=\"/UxCQFFFFFFFaaYAH/something-fantastic\"><img alt=\"\" src=\"http://fpoimg.com/400x400\" width=\"400\" height=\"400\" /></a></p><p>The next is linked to a broken document:</p><p class=\"block-img\"><a href=\"#broken\"><img alt=\"\" src=\"http://fpoimg.com/250x250\" width=\"250\" height=\"250\" /></a></p><p>One more image, this one is not linked:</p><p class=\"block-img\"><img alt=\"\" src=\"http://fpoimg.com/199x300\" width=\"300\" height=\"199\" /></p>",
+      "<p>Here is some introductory text.</p><p>The following image is linked.</p><p class=\"block-img\"><a href=\"http://google.com/\"><img alt=\"\" src=\"http://fpoimg.com/129x260\" width=\"260\" height=\"129\" /></a></p><p>The following image is linked with a target blank.</p><p class=\"block-img\"><a href=\"http://google.com/\" target=\"_blank\" rel=\"noopener\"><img alt=\"\" src=\"http://fpoimg.com/129x260\" width=\"260\" height=\"129\" /></a></p><p><strong>More important stuff</strong></p><p>The next is linked to a valid document:</p><p class=\"block-img\"><a href=\"/UxCQFFFFFFFaaYAH/something-fantastic\"><img alt=\"\" src=\"http://fpoimg.com/400x400\" width=\"400\" height=\"400\" /></a></p><p>The next is linked to a broken document:</p><p class=\"block-img\"><a href=\"#broken\"><img alt=\"\" src=\"http://fpoimg.com/250x250\" width=\"250\" height=\"250\" /></a></p><p>One more image, this one is not linked:</p><p class=\"block-img\"><img alt=\"\" src=\"http://fpoimg.com/199x300\" width=\"300\" height=\"199\" /></p>",
       text.asHtml(linkResolver)
     );
   }
@@ -229,6 +229,18 @@ public class DocumentTest {
   }
 
   @Test
+  public void targetBlankRichText() throws Exception {
+    ObjectMapper mapper = new ObjectMapper();
+    String jsonString = "{ \"type\": \"StructuredText\", \"value\": [ { \"type\": \"paragraph\", \"text\": \"Target blank link\", \"spans\": [ { \"start\": 0, \"end\": 17, \"type\": \"hyperlink\", \"data\": { \"type\": \"Link.web\", \"value\": { \"url\": \"https://google.com\", \"target\": \"_blank\" } } } ] } ]}";
+    JsonNode json = mapper.readTree(jsonString);
+    Fragment.StructuredText text = Fragment.StructuredText.parse(json.path("value"));
+    Assert.assertEquals(
+      "<p><a href=\"https://google.com\" target=\"_blank\" rel=\"noopener\">Target blank link</a></p>",
+      text.asHtml(linkResolver)
+    );
+  }
+
+  @Test
   public void labelSpans() throws Exception {
     ObjectMapper mapper = new ObjectMapper();
     String jsonString = "{\"type\":\"StructuredText\",\"value\":[{\"type\":\"paragraph\",\"text\":\"To query your API, you will need to specify a form and a reference in addition to your query.\",\"spans\":[{\"start\":46,\"end\":50,\"type\":\"strong\"},{\"start\":57,\"end\":67,\"type\":\"strong\"},{\"start\":78,\"end\":92,\"type\":\"strong\"}]},{\"type\":\"list-item\",\"text\":\"The operator: this is the function you call to build the predicate, for example Predicate.at.\",\"spans\":[{\"start\":4,\"end\":12,\"type\":\"em\"},{\"start\":80,\"end\":92,\"type\":\"label\",\"data\":{\"label\":\"codespan\"}}]},{\"type\":\"list-item\",\"text\":\"The fragment: the first argument you pass, for example document.id.\",\"spans\":[{\"start\":4,\"end\":12,\"type\":\"em\"},{\"start\":55,\"end\":67,\"type\":\"label\",\"data\":{\"label\":\"codespan\"}}]},{\"type\":\"list-item\",\"text\":\"The values: the other arguments you pass, usually one but it can be more for some predicates. For example product.\",\"spans\":[{\"start\":4,\"end\":10,\"type\":\"em\"},{\"start\":106,\"end\":113,\"type\":\"label\",\"data\":{\"label\":\"codespan\"}}]}]}";
@@ -238,6 +250,18 @@ public class DocumentTest {
     Assert.assertEquals(
       "<p>To query your API, you will need to specify a <strong>form</strong> and a <strong>reference </strong>in addition<strong> to your query</strong>.</p><ul><li>The <em>operator</em>: this is the function you call to build the predicate, for example <span class=\"codespan\">Predicate.at</span>.</li><li>The <em>fragment</em>: the first argument you pass, for example <span class=\"codespan\">document.id.</span></li><li>The <em>values</em>: the other arguments you pass, usually one but it can be more for some predicates. For example <span class=\"codespan\">product</span>.</li></ul>",
       text.asHtml(linkResolver)
+    );
+  }
+
+  @Test
+  public void targetBlankLink() throws Exception {
+    ObjectMapper mapper = new ObjectMapper();
+    String jsonString = "{ \"type\": \"Link.web\", \"value\": { \"url\": \"https://google.com\", \"target\": \"_blank\" } }";
+    JsonNode json = mapper.readTree(jsonString);
+    Fragment.WebLink target = Fragment.WebLink.parse(json.path("value"));
+    Assert.assertEquals(
+      "_blank",
+      target.getTarget()
     );
   }
 


### PR DESCRIPTION
This adds support for the Target Blank feature of prismic.io.

It includes the target blank attribute for Links as well as hyperlinks in Rich Text fields.

This also adds tests for target blank.