### PR TITLE
Convert line separators in JSON to line breaks in HTML

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.5.0/apache-maven-3.5.0-bin.zip
+distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.5.2/apache-maven-3.5.2-bin.zip

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.prismic</groupId>
     <artifactId>java-kit</artifactId>
     <packaging>jar</packaging>
-    <version>1.6.2</version>
+    <version>1.6.3-SNAPSHOT</version>
     <name>java-kit</name>
     <description>The developer kit to access Prismic.io repositories using the Java language.</description>
     <url>http://maven.apache.org</url>

--- a/src/main/java/io/prismic/Fragment.java
+++ b/src/main/java/io/prismic/Fragment.java
@@ -1205,7 +1205,7 @@ public interface Fragment {
           }
         }
       }
-      return html.toString();
+      return convertLineSeparatorsToHtmlLineBreaks(html.toString());
     }
 
     public String asHtml(Block block, LinkResolver linkResolver, HtmlSerializer htmlSerializer) {
@@ -1266,6 +1266,10 @@ public interface Fragment {
         this.x = x;
         this.y = y;
       }
+    }
+
+    private String convertLineSeparatorsToHtmlLineBreaks(String html) {
+      return html.replaceAll("\n", "<br/>");
     }
 
     private static String serialize(Span span, String content, LinkResolver linkResolver, HtmlSerializer htmlSerializer) {

--- a/src/test/java/io/prismic/DocumentTest.java
+++ b/src/test/java/io/prismic/DocumentTest.java
@@ -3,7 +3,6 @@ package io.prismic;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import junit.framework.Assert;
-
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Test;
@@ -246,7 +245,6 @@ public class DocumentTest {
     String jsonString = "{\"type\":\"StructuredText\",\"value\":[{\"type\":\"paragraph\",\"text\":\"To query your API, you will need to specify a form and a reference in addition to your query.\",\"spans\":[{\"start\":46,\"end\":50,\"type\":\"strong\"},{\"start\":57,\"end\":67,\"type\":\"strong\"},{\"start\":78,\"end\":92,\"type\":\"strong\"}]},{\"type\":\"list-item\",\"text\":\"The operator: this is the function you call to build the predicate, for example Predicate.at.\",\"spans\":[{\"start\":4,\"end\":12,\"type\":\"em\"},{\"start\":80,\"end\":92,\"type\":\"label\",\"data\":{\"label\":\"codespan\"}}]},{\"type\":\"list-item\",\"text\":\"The fragment: the first argument you pass, for example document.id.\",\"spans\":[{\"start\":4,\"end\":12,\"type\":\"em\"},{\"start\":55,\"end\":67,\"type\":\"label\",\"data\":{\"label\":\"codespan\"}}]},{\"type\":\"list-item\",\"text\":\"The values: the other arguments you pass, usually one but it can be more for some predicates. For example product.\",\"spans\":[{\"start\":4,\"end\":10,\"type\":\"em\"},{\"start\":106,\"end\":113,\"type\":\"label\",\"data\":{\"label\":\"codespan\"}}]}]}";
     JsonNode json = mapper.readTree(jsonString);
     Fragment.StructuredText text = Fragment.StructuredText.parse(json.path("value"));
-    System.out.println(text.asHtml(linkResolver));
     Assert.assertEquals(
       "<p>To query your API, you will need to specify a <strong>form</strong> and a <strong>reference </strong>in addition<strong> to your query</strong>.</p><ul><li>The <em>operator</em>: this is the function you call to build the predicate, for example <span class=\"codespan\">Predicate.at</span>.</li><li>The <em>fragment</em>: the first argument you pass, for example <span class=\"codespan\">document.id.</span></li><li>The <em>values</em>: the other arguments you pass, usually one but it can be more for some predicates. For example <span class=\"codespan\">product</span>.</li></ul>",
       text.asHtml(linkResolver)
@@ -262,6 +260,18 @@ public class DocumentTest {
     Assert.assertEquals(
       "_blank",
       target.getTarget()
+    );
+  }
+
+  @Test
+  public void lineBreaks() throws Exception {
+    ObjectMapper mapper = new ObjectMapper();
+    String jsonString = "{ \"type\": \"StructuredText\", \"value\": [ { \"type\": \"paragraph\", \"text\": \"Line\\nwith\\n\\nline breaks\", \"spans\": [] } ]}";
+    JsonNode json = mapper.readTree(jsonString);
+    Fragment.StructuredText text = Fragment.StructuredText.parse(json.path("value"));
+    Assert.assertEquals(
+      "<p>Line<br/>with<br/><br/>line breaks</p>",
+      text.asHtml(linkResolver)
     );
   }
 


### PR DESCRIPTION
Hello,

In Prismic writing room, when a writer use carriage return (`Shift`+`Enter` or using Copy-Paste) in a paragraph, the `asHtml` function returns `\n` characters in the result in the middle of the markup. But `\n` character cannot be seen in a browser.
This PR converts these line separator characters to html break line tag `<br/>`

Thanks!

@Aigrefin & @damienbeaufils