### PR TITLE
[enhancement] Support integration field (and any other unknown field)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 
 jdk:
-  - openjdk7
   - openjdk8
   - oraclejdk8
   - oraclejdk9

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This library is on Maven Central. The kit coordinates are:
 
 *(you may need to adapt the version number)*
 
-The kit requires **Java 7** or superior.
+The kit requires **Java 8** or superior.
 
 #### Documentation
 
@@ -38,13 +38,13 @@ Always run ```./mvnw test``` before committing, to make sure everything runs as 
 
 #### Test
 
-Please write tests using [JUnit3](http://junit.sourceforge.net/junit3.8.1/) for any bugfix or new feature; please add the tests to the [AppTest.java file](https://github.com/prismicio/java-kit/blob/master/src/test/java/io/prismic/AppTest.java). Run ```./mvnw test``` to test.
+Please write tests using [JUnit4](http://junit.org/junit4/) for any bugfix or new feature; please add the tests to the [AppTest.java file](https://github.com/prismicio/java-kit/blob/master/src/test/java/io/prismic/AppTest.java). Run ```./mvnw test``` to test.
 
 If you find existing code that is not optimally tested and wish to make it better, we really appreciate it; but you should document it on its own branch and its own pull request.
 
 #### Documenting
 
-Please document any bugfix or new feature using the [Javadoc syntax](http://docs.oracle.com/javase/1.5.0/docs/tooldocs/windows/javadoc.html)
+Please document any bugfix or new feature using the [Javadoc syntax](https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html)
 
 If you find existing code that is not optimally documented and wish to make it better, we really appreciate it; but you should document it on its own branch and its own pull request.
 
@@ -58,7 +58,7 @@ If you find existing code that is not optimally documented and wish to make it b
 
 This software is licensed under the Apache 2 license, quoted below.
 
-Copyright 2017 Prismic.io (https://prismic.io).
+Copyright 2018 Prismic.io (https://prismic.io).
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this project except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
 

--- a/pom.xml
+++ b/pom.xml
@@ -99,14 +99,14 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- JDK 1.6 source and binary compatiblility -->
+            <!-- JDK 1.8 source and binary compatiblility -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.7.0</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.0-M1</version>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -127,12 +127,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.7.1-1</version>
+            <version>2.9.3</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
-            <version>2.9.2</version>
+            <version>2.9.9</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -142,7 +142,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.4</version>
+            <version>2.6</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
@@ -159,7 +159,7 @@
         <dependency>
           <groupId>org.littleshoot</groupId>
           <artifactId>littleproxy</artifactId>
-          <version>1.1.0</version>
+          <version>1.1.2</version>
         </dependency>
         <!--logger -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.prismic</groupId>
     <artifactId>java-kit</artifactId>
     <packaging>jar</packaging>
-    <version>1.6.3-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <name>java-kit</name>
     <description>The developer kit to access Prismic.io repositories using the Java language.</description>
     <url>http://maven.apache.org</url>

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,10 @@
         </repository>
     </distributionManagement>
 
+    <properties>
+      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
     <build>
         <resources>
             <resource>

--- a/src/main/java/io/prismic/Api.java
+++ b/src/main/java/io/prismic/Api.java
@@ -442,7 +442,7 @@ public class Api {
     if (ref == null) {
       ref = this.defaultReference == null ? this.getMaster().getRef() : this.defaultReference;
     }
-    return this.getByID(this.apiData.bookmarks.get(bookmark));
+    return this.getByID(this.apiData.bookmarks.get(bookmark), ref);
   }
 
   public Document getBookmark(String bookmark) {

--- a/src/main/java/io/prismic/Api.java
+++ b/src/main/java/io/prismic/Api.java
@@ -1,14 +1,13 @@
 package io.prismic;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import io.prismic.core.HttpClient;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.Proxy;
 import java.util.*;
 import java.util.Map.Entry;
-
-import io.prismic.core.*;
-
-import com.fasterxml.jackson.databind.*;
 
 /**
  * Embodies an API endpoint, from which it is possible to make queries.

--- a/src/main/java/io/prismic/Api.java
+++ b/src/main/java/io/prismic/Api.java
@@ -53,6 +53,16 @@ public class Api {
       this.code = code;
     }
 
+    public Error(Code code, String message, Throwable throwable) {
+      super(message, throwable);
+      this.code = code;
+    }
+
+    public Error(Code code, Throwable throwable) {
+      super(throwable);
+      this.code = code;
+    }
+
     public Code getCode() {
       return code;
     }

--- a/src/main/java/io/prismic/Api.java
+++ b/src/main/java/io/prismic/Api.java
@@ -93,7 +93,7 @@ public class Api {
     ApiData apiData = ApiData.parse(json);
     return new Api(apiData, accessToken, defaultReference, cache, logger, proxy);
   }
-  
+
   /**
    * Entry point to get an {@link Api} object.
    * Example: <code>API api = API.get("https://lesbonneschoses.prismic.io/api", null, new Cache.BuiltInCache(999), new Logger.PrintlnLogger());</code>
@@ -201,7 +201,7 @@ public class Api {
   public Cache getCache() {
     return cache;
   }
-  
+
   public Proxy getProxy() {
 		return proxy;
 	}
@@ -269,7 +269,7 @@ public class Api {
    * @return the map &lt;name, proper_name&gt;
    */
   public Map<String, String> getFormNames() {
-      Map<String, String> formNames = new HashMap<String, String>();
+      Map<String, String> formNames = new HashMap<>();
       if (apiData.getForms() != null)
           for(Entry<String, Form> formEntry : apiData.getForms().entrySet())
               formNames.put(formEntry.getKey(), formEntry.getValue().getName());
@@ -549,33 +549,33 @@ public class Api {
     // --
 
     static ApiData parse(JsonNode json) {
-      List<Ref> refs = new ArrayList<Ref>();
+      List<Ref> refs = new ArrayList<>();
       Iterator<JsonNode> refsJson = json.withArray("refs").elements();
       while(refsJson.hasNext()) {
         refs.add(Ref.parse(refsJson.next()));
       }
 
-      Map<String,String> bookmarks = new HashMap<String,String>();
+      Map<String,String> bookmarks = new HashMap<>();
       Iterator<String> bookmarksJson = json.with("bookmarks").fieldNames();
       while(bookmarksJson.hasNext()) {
         String bookmark = bookmarksJson.next();
         bookmarks.put(bookmark, json.with("bookmarks").path(bookmark).asText());
       }
 
-      Map<String,String> types = new HashMap<String,String>();
+      Map<String,String> types = new HashMap<>();
       Iterator<String> typesJson = json.with("types").fieldNames();
       while(typesJson.hasNext()) {
         String type = typesJson.next();
         types.put(type, json.with("types").path(type).asText());
       }
 
-      List<String> tags = new ArrayList<String>();
+      List<String> tags = new ArrayList<>();
       Iterator<JsonNode> tagsJson = json.withArray("tags").elements();
       while(tagsJson.hasNext()) {
         tags.add(tagsJson.next().asText());
       }
 
-      Map<String,Form> forms = new HashMap<String,Form>();
+      Map<String,Form> forms = new HashMap<>();
       Iterator<String> formsJson = json.with("forms").fieldNames();
       while(formsJson.hasNext()) {
         String form = formsJson.next();

--- a/src/main/java/io/prismic/Api.java
+++ b/src/main/java/io/prismic/Api.java
@@ -80,13 +80,9 @@ public class Api {
   public static Api get(String endpoint, String accessToken, String defaultReference, final Cache cache, final Logger logger, final Proxy proxy) {
     final String url = (accessToken == null ? endpoint : (endpoint + "?access_token=" + HttpClient.encodeURIComponent(accessToken)));
     JsonNode json = cache.getOrSet(
-        url,
-        5000L,
-        new Cache.Callback() {
-            public JsonNode execute() {
-                return HttpClient.fetch(url, logger, null, proxy);
-            }
-        }
+      url,
+      5000L,
+      () -> HttpClient.fetch(url, logger, null, proxy)
     );
 
     ApiData apiData = ApiData.parse(json);

--- a/src/main/java/io/prismic/Cache.java
+++ b/src/main/java/io/prismic/Cache.java
@@ -5,12 +5,12 @@ import org.apache.commons.collections4.map.LRUMap;
 
 public interface Cache {
 
-  public void set(String key, Long ttl, JsonNode response);
-  public JsonNode get(String key);
-  public JsonNode getOrSet(String key, Long ttl, Callback f);
+  void set(String key, Long ttl, JsonNode response);
+  JsonNode get(String key);
+  JsonNode getOrSet(String key, Long ttl, Callback f);
 
   // --
-  public static class NoCache implements Cache {
+  class NoCache implements Cache {
 
     @Override
     public void set(String key, Long ttl, JsonNode response) {
@@ -30,7 +30,7 @@ public interface Cache {
 
   // --
 
-  public static class DefaultCache {
+  class DefaultCache {
 
     private static Cache defaultCache = new BuiltInCache(999);
 
@@ -43,11 +43,11 @@ public interface Cache {
 
   // --
 
-  public interface Callback {
-    public JsonNode execute();
+  interface Callback {
+    JsonNode execute();
   }
 
-  public static class BuiltInCache implements Cache {
+  class BuiltInCache implements Cache {
 
     private final java.util.Map<String, Entry> cache;
 
@@ -93,7 +93,7 @@ public interface Cache {
     }
 
     private Boolean isExpired(String key) {
-      Entry entry = (Entry)this.cache.get(key);
+      Entry entry = this.cache.get(key);
       return entry != null && entry.expiration !=0 && entry.expiration < System.currentTimeMillis();
     }
 

--- a/src/main/java/io/prismic/Cache.java
+++ b/src/main/java/io/prismic/Cache.java
@@ -1,6 +1,6 @@
 package io.prismic;
 
-import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.commons.collections4.map.LRUMap;
 
 public interface Cache {

--- a/src/main/java/io/prismic/Cache.java
+++ b/src/main/java/io/prismic/Cache.java
@@ -32,7 +32,7 @@ public interface Cache {
 
   class DefaultCache {
 
-    private static Cache defaultCache = new BuiltInCache(999);
+    private static final Cache defaultCache = new BuiltInCache(999);
 
     private DefaultCache() {}
 

--- a/src/main/java/io/prismic/Callback.java
+++ b/src/main/java/io/prismic/Callback.java
@@ -1,5 +1,5 @@
 package io.prismic;
 
 public interface Callback {
-    public void execute();
+    void execute();
 }

--- a/src/main/java/io/prismic/Document.java
+++ b/src/main/java/io/prismic/Document.java
@@ -1,6 +1,7 @@
 package io.prismic;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.prismic.Fragment.Link;
 import org.joda.time.DateTime;
 
 import java.io.UnsupportedEncodingException;
@@ -105,53 +106,39 @@ public class Document extends WithFragments {
 
   // --
   static Fragment parseFragment(String type, JsonNode json) {
-    if("StructuredText".equals(type)) {
-      return Fragment.StructuredText.parse(json);
-    }
-    else if("Image".equals(type)) {
-      return Fragment.Image.parse(json);
-    }
-    else if("Link.web".equals(type)) {
-      return Fragment.Link.WebLink.parse(json);
-    }
-    else if("Link.document".equals(type)) {
-      return Fragment.Link.DocumentLink.parse(json);
-    }
-    else if("Link.file".equals(type)) {
-      return Fragment.Link.FileLink.parse(json);
-    }
-    else if("Link.image".equals(type)) {
-      return Fragment.Link.ImageLink.parse(json);
-    }
-    else if("Text".equals(type)) {
-      return Fragment.Text.parse(json);
-    }
-    else if("Select".equals(type)) {
-      return Fragment.Text.parse(json);
-    }
-    else if("Date".equals(type)) {
-      return Fragment.Date.parse(json);
-    }
-    else if("Timestamp".equals(type)) {
-      return Fragment.Timestamp.parse(json);
-    }
-    else if("Number".equals(type)) {
-      return Fragment.Number.parse(json);
-    }
-    else if("Color".equals(type)) {
-      return Fragment.Color.parse(json);
-    }
-    else if("Embed".equals(type)) {
-      return Fragment.Embed.parse(json);
-    }
-    else if("GeoPoint".equals(type)) {
+    switch (type) {
+      case "StructuredText":
+        return Fragment.StructuredText.parse(json);
+      case "Image":
+        return Fragment.Image.parse(json);
+      case "Link.web":
+        return Link.WebLink.parse(json);
+      case "Link.document":
+        return Link.DocumentLink.parse(json);
+      case "Link.file":
+        return Link.FileLink.parse(json);
+      case "Link.image":
+        return Link.ImageLink.parse(json);
+      case "Text":
+        return Fragment.Text.parse(json);
+      case "Select":
+        return Fragment.Text.parse(json);
+      case "Date":
+        return Fragment.Date.parse(json);
+      case "Timestamp":
+        return Fragment.Timestamp.parse(json);
+      case "Number":
+        return Fragment.Number.parse(json);
+      case "Color":
+        return Fragment.Color.parse(json);
+      case "Embed":
+        return Fragment.Embed.parse(json);
+      case "GeoPoint":
         return Fragment.GeoPoint.parse(json);
-    }
-    else if("Group".equals(type)) {
-      return Fragment.Group.parse(json);
-    }
-    else if("SliceZone".equals(type)) {
-      return Fragment.SliceZone.parse(json);
+      case "Group":
+        return Fragment.Group.parse(json);
+      case "SliceZone":
+        return Fragment.SliceZone.parse(json);
     }
     return null;
   }

--- a/src/main/java/io/prismic/Document.java
+++ b/src/main/java/io/prismic/Document.java
@@ -159,7 +159,7 @@ public class Document extends WithFragments {
 
   static Map<String, Fragment> parseFragments(JsonNode json, String type) {
     Iterator<String> dataJson = json.fieldNames();
-    Map<String, Fragment> fragments = new LinkedHashMap<String, Fragment>();
+    Map<String, Fragment> fragments = new LinkedHashMap<>();
     while(dataJson.hasNext()) {
       String field = dataJson.next();
       JsonNode fieldJson = json.path(field);
@@ -197,7 +197,7 @@ public class Document extends WithFragments {
     DateTime lastPublicationDate = parseDateTime(json.path("last_publication_date"));
 
     Iterator<JsonNode> alternateLanguagesJson = json.withArray("alternate_languages").elements();
-    List<AlternateLanguage> alternateLanguages = new ArrayList<AlternateLanguage>();
+    List<AlternateLanguage> alternateLanguages = new ArrayList<>();
     while(alternateLanguagesJson.hasNext()) {
       JsonNode altLangJson = alternateLanguagesJson.next();
       String altLangId = altLangJson.path("id").asText();
@@ -208,13 +208,13 @@ public class Document extends WithFragments {
     }
 
     Iterator<JsonNode> tagsJson = json.withArray("tags").elements();
-    Set<String> tags = new HashSet<String>();
+    Set<String> tags = new HashSet<>();
     while(tagsJson.hasNext()) {
       tags.add(tagsJson.next().asText());
     }
 
     Iterator<JsonNode> slugsJson = json.withArray("slugs").elements();
-    List<String> slugs = new ArrayList<String>();
+    List<String> slugs = new ArrayList<>();
     while(slugsJson.hasNext()) {
       try {
         slugs.add(URLDecoder.decode(slugsJson.next().asText(), "UTF-8"));

--- a/src/main/java/io/prismic/Document.java
+++ b/src/main/java/io/prismic/Document.java
@@ -104,7 +104,6 @@ public class Document extends WithFragments {
     return new Fragment.DocumentLink(id, uid, type, tags, getSlug(), lang, fragments, false);
   }
 
-  // --
   static Fragment parseFragment(String type, JsonNode json) {
     switch (type) {
       case "StructuredText":
@@ -139,8 +138,9 @@ public class Document extends WithFragments {
         return Fragment.Group.parse(json);
       case "SliceZone":
         return Fragment.SliceZone.parse(json);
+      default:
+        return Fragment.Raw.parse(json);
     }
-    return null;
   }
 
   static Map<String, Fragment> parseFragments(JsonNode json, String type) {

--- a/src/main/java/io/prismic/Document.java
+++ b/src/main/java/io/prismic/Document.java
@@ -156,18 +156,14 @@ public class Document extends WithFragments {
           String fragmentType = fieldJson.path(i).path("type").asText();
           JsonNode fragmentValue = fieldJson.path(i).path("value");
           Fragment fragment = parseFragment(fragmentType, fragmentValue);
-          if(fragment != null) {
-            fragments.put(fragmentName, fragment);
-          }
+          fragments.put(fragmentName, fragment);
         }
       } else {
         String fragmentName = type + "." + field;
         String fragmentType = fieldJson.path("type").asText();
         JsonNode fragmentValue = fieldJson.path("value");
         Fragment fragment = parseFragment(fragmentType, fragmentValue);
-        if(fragment != null) {
-          fragments.put(fragmentName, fragment);
-        }
+        fragments.put(fragmentName, fragment);
       }
     }
     return fragments;

--- a/src/main/java/io/prismic/Document.java
+++ b/src/main/java/io/prismic/Document.java
@@ -1,12 +1,11 @@
 package io.prismic;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import org.joda.time.DateTime;
+
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.*;
-
-import org.joda.time.DateTime;
-
-import com.fasterxml.jackson.databind.*;
 
 public class Document extends WithFragments {
 

--- a/src/main/java/io/prismic/Experiment.java
+++ b/src/main/java/io/prismic/Experiment.java
@@ -44,7 +44,7 @@ public class Experiment {
     String googleId = json.path("googleId").asText();
     String name = json.path("name").asText();
 
-    List<Variation> variations = new ArrayList<Variation>();
+    List<Variation> variations = new ArrayList<>();
     Iterator<JsonNode> variationsJson = json.withArray("variations").elements();
     while(variationsJson.hasNext()) {
       variations.add(Variation.parse(variationsJson.next()));

--- a/src/main/java/io/prismic/Experiments.java
+++ b/src/main/java/io/prismic/Experiments.java
@@ -26,7 +26,7 @@ public class Experiments {
    */
   public synchronized List<Experiment> getAll() {
     if (all == null) {
-      all = new ArrayList<Experiment>();
+      all = new ArrayList<>();
       all.addAll(this.draft);
       all.addAll(this.running);
     }
@@ -78,8 +78,8 @@ public class Experiments {
   }
 
   public static Experiments parse(JsonNode json) {
-    List<Experiment> draft = new ArrayList<Experiment>();
-    List<Experiment> running = new ArrayList<Experiment>();
+    List<Experiment> draft = new ArrayList<>();
+    List<Experiment> running = new ArrayList<>();
     Iterator<JsonNode> it;
 
     JsonNode draftJson = json.path("draft");

--- a/src/main/java/io/prismic/Form.java
+++ b/src/main/java/io/prismic/Form.java
@@ -1,10 +1,9 @@
 package io.prismic;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import io.prismic.core.HttpClient;
+
 import java.util.*;
-
-import com.fasterxml.jackson.databind.*;
-
-import io.prismic.core.*;
 
 /**
  * A general usage RESTful form, manipulated by higher-level forms like {@link Form.SearchForm}.

--- a/src/main/java/io/prismic/Form.java
+++ b/src/main/java/io/prismic/Form.java
@@ -103,7 +103,7 @@ public class Form {
     String enctype = json.path("enctype").asText();
     String action = json.path("action").asText();
 
-    Map<String,Field> fields = new HashMap<String,Field>();
+    Map<String,Field> fields = new HashMap<>();
     Iterator<String> fieldsJson = json.with("fields").fieldNames();
     while(fieldsJson.hasNext()) {
       String field = fieldsJson.next();
@@ -133,10 +133,10 @@ public class Form {
     public SearchForm(Api api, Form form) {
       this.api = api;
       this.form = form;
-      this.data = new HashMap<String,List<String>>();
+      this.data = new HashMap<>();
       for(Map.Entry<String,Field> field: form.getFields().entrySet())
         if (field.getValue().getDefaultValue() != null) {
-          List<String> value = new ArrayList<String>(1);
+          List<String> value = new ArrayList<>(1);
           value.add(field.getValue().getDefaultValue());
           this.data.put(field.getKey(), value);
         }
@@ -163,12 +163,12 @@ public class Form {
       if (fieldDesc.isMultiple()) {
         List<String> existingValue = data.get(field);
         if(existingValue == null) {
-          existingValue = new ArrayList<String>();
+          existingValue = new ArrayList<>();
         }
         existingValue.add(value);
         data.put(field, existingValue);
       } else {
-        List<String> newValue = new ArrayList<String>();
+        List<String> newValue = new ArrayList<>();
         newValue.add(value);
         data.put(field, newValue);
       }
@@ -364,7 +364,7 @@ public class Form {
       if(fieldDesc != null && fieldDesc.isMultiple()) {
         return set("q", q);
       } else {
-        List<String> value = new ArrayList<String>();
+        List<String> value = new ArrayList<>();
         value.add(("[ " + (form.getFields().containsKey("q") ? strip(form.getFields().get("q").getDefaultValue()) : "") + " " + strip(q) + " ]"));
         this.data.put("q", value);
         return this;

--- a/src/main/java/io/prismic/Fragment.java
+++ b/src/main/java/io/prismic/Fragment.java
@@ -1596,4 +1596,28 @@ public interface Fragment {
 
   }
 
+  /**
+   * Represents a raw fragment from which you can retrieve json in order to handle it manually
+   */
+  class Raw implements Fragment {
+
+    private final JsonNode value;
+
+    public Raw(JsonNode value) {
+      this.value = value;
+    }
+
+    public JsonNode getValue() {
+      return value;
+    }
+
+    public String asText() {
+      return value.toString();
+    }
+
+    public static Raw parse(JsonNode json) {
+      return new Raw(json);
+    }
+  }
+
 }

--- a/src/main/java/io/prismic/Fragment.java
+++ b/src/main/java/io/prismic/Fragment.java
@@ -738,7 +738,7 @@ public interface Fragment {
     public String asHtml(LinkResolver linkResolver) {
       String className = "slice";
       if (this.label != null && !this.label.equals("null")) className += (" " + this.label);
-      List<GroupDoc> groupDocs = new ArrayList<>(Arrays.asList(this.nonRepeat));
+      List<GroupDoc> groupDocs = new ArrayList<>(Collections.singletonList(this.nonRepeat));
       Group nonRepeat = this.nonRepeat != null ? new Group(groupDocs) : null;
       return "<div data-slicetype=\"" + this.sliceType + "\" class=\"" + className + "\">" +
         WithFragments.fragmentHtml(nonRepeat, linkResolver, null) +
@@ -1196,11 +1196,11 @@ public interface Fragment {
       StringBuilder html = new StringBuilder();
       for(BlockGroup blockGroup: blockGroups) {
         if(blockGroup.tag != null) {
-          html.append("<" + blockGroup.tag + ">");
+          html.append("<").append(blockGroup.tag).append(">");
           for(Block block: blockGroup.blocks) {
             html.append(asHtml(block, linkResolver, htmlSerializer));
           }
-          html.append("</" + blockGroup.tag + ">");
+          html.append("</").append(blockGroup.tag).append(">");
         } else {
           for(Block block: blockGroup.blocks) {
             html.append(asHtml(block, linkResolver, htmlSerializer));
@@ -1334,7 +1334,7 @@ public interface Fragment {
       }
 
       char c;
-      String html = "";
+      StringBuilder html = new StringBuilder();
       Stack<Tuple<Span, String>> stack = new Stack<>();
       for (int pos = 0, len = text.length(); pos < len; pos++) {
         if (tagsEnd.containsKey(pos)) {
@@ -1344,7 +1344,7 @@ public interface Fragment {
             String innerHtml = serialize(tag.x, tag.y, linkResolver, htmlSerializer);
             if (stack.isEmpty()) {
               // The tag was top level
-              html += innerHtml;
+              html.append(innerHtml);
             } else {
               // Add the content to the parent tag
               Tuple<Span, String> head = stack.pop();
@@ -1362,7 +1362,7 @@ public interface Fragment {
         String escaped = escape(Character.toString(c));
         if (stack.isEmpty()) {
           // Top-level text
-          html += escaped;
+          html.append(escaped);
         } else {
           // Inner text of a span
           Tuple<Span, String> head = stack.pop();
@@ -1375,14 +1375,14 @@ public interface Fragment {
         String innerHtml = serialize(tag.x, tag.y, linkResolver, htmlSerializer);
         if (stack.isEmpty()) {
           // The tag was top level
-          html += innerHtml;
+          html.append(innerHtml);
         } else {
           // Add the content to the parent tag
           Tuple<Span, String> head = stack.pop();
           stack.push(new Tuple<>(head.x, head.y + innerHtml));
         }
       }
-      return html;
+      return html.toString();
     }
 
     public String asHtml(LinkResolver linkResolver) {

--- a/src/main/java/io/prismic/Fragment.java
+++ b/src/main/java/io/prismic/Fragment.java
@@ -1405,17 +1405,15 @@ public interface Fragment {
       }
       String linkType = json.path("type").asText();
       JsonNode value = json.with("value");
-      if("Link.web".equals(linkType)) {
-        return Link.WebLink.parse(value);
-      }
-      else if("Link.document".equals(linkType)) {
-        return Link.DocumentLink.parse(value);
-      }
-      else if("Link.file".equals(linkType)) {
-        return Link.FileLink.parse(value);
-      }
-      else if("Link.image".equals(linkType)) {
-        return Link.ImageLink.parse(value);
+      switch (linkType) {
+        case "Link.web":
+          return WebLink.parse(value);
+        case "Link.document":
+          return DocumentLink.parse(value);
+        case "Link.file":
+          return FileLink.parse(value);
+        case "Link.image":
+          return ImageLink.parse(value);
       }
       return null;
     }

--- a/src/main/java/io/prismic/Fragment.java
+++ b/src/main/java/io/prismic/Fragment.java
@@ -546,7 +546,7 @@ public interface Fragment {
       String type = document.path("type").asText();
       String slug = document.path("slug").asText();
       String lang = document.path("lang").asText();
-      Set<String> tags = new HashSet<String>();
+      Set<String> tags = new HashSet<>();
       for(JsonNode tagJson: document.withArray("tags")) {
         tags.add(tagJson.asText());
       }
@@ -656,7 +656,7 @@ public interface Fragment {
     }
 
     public Image(View main) {
-      this(main, new HashMap<String,View>());
+      this(main, new HashMap<>());
     }
 
     /**
@@ -698,7 +698,7 @@ public interface Fragment {
 
     public static Image parse(JsonNode json) {
       View main = View.parse(json.with("main"));
-      Map<String,View> views = new HashMap<String,View>();
+      Map<String,View> views = new HashMap<>();
       Iterator<String> viewsJson = json.with("views").fieldNames();
       while(viewsJson.hasNext()) {
         String view = viewsJson.next();
@@ -737,7 +737,7 @@ public interface Fragment {
     public String asHtml(LinkResolver linkResolver) {
       String className = "slice";
       if (this.label != null && !this.label.equals("null")) className += (" " + this.label);
-      List<GroupDoc> groupDocs = new ArrayList<GroupDoc>(Arrays.asList(this.nonRepeat));
+      List<GroupDoc> groupDocs = new ArrayList<>(Arrays.asList(this.nonRepeat));
       Group nonRepeat = this.nonRepeat != null ? new Group(groupDocs) : null;
       return "<div data-slicetype=\"" + this.sliceType + "\" class=\"" + className + "\">" +
         WithFragments.fragmentHtml(nonRepeat, linkResolver, null) +
@@ -820,7 +820,7 @@ public interface Fragment {
     }
 
     public static SliceZone parse(JsonNode json) {
-      List<Slice> slices = new ArrayList<Slice>();
+      List<Slice> slices = new ArrayList<>();
       for(JsonNode sliceJson: json) {
         String sliceType = sliceJson.path("slice_type").asText();
         String label = sliceJson.has("slice_label") ? sliceJson.path("slice_label").asText() : null;
@@ -1167,7 +1167,7 @@ public interface Fragment {
     }
 
     public String asHtml(List<Block> blocks, LinkResolver linkResolver, HtmlSerializer htmlSerializer) {
-      List<BlockGroup> blockGroups = new ArrayList<BlockGroup>();
+      List<BlockGroup> blockGroups = new ArrayList<>();
       for(Block block: blocks) {
         BlockGroup lastOne = blockGroups.isEmpty() ? null : blockGroups.get(blockGroups.size() - 1);
         if(lastOne != null && "ul".equals(lastOne.tag) && block instanceof Block.ListItem && !((Block.ListItem)block).isOrdered()) {
@@ -1177,17 +1177,17 @@ public interface Fragment {
           lastOne.blocks.add(block);
         }
         else if(block instanceof Block.ListItem && !((Block.ListItem)block).isOrdered()) {
-          BlockGroup newBlockGroup = new BlockGroup("ul", new ArrayList<Block>());
+          BlockGroup newBlockGroup = new BlockGroup("ul", new ArrayList<>());
           newBlockGroup.blocks.add(block);
           blockGroups.add(newBlockGroup);
         }
         else if(block instanceof Block.ListItem && ((Block.ListItem)block).isOrdered()) {
-          BlockGroup newBlockGroup = new BlockGroup("ol", new ArrayList<Block>());
+          BlockGroup newBlockGroup = new BlockGroup("ol", new ArrayList<>());
           newBlockGroup.blocks.add(block);
           blockGroups.add(newBlockGroup);
         }
         else {
-          BlockGroup newBlockGroup = new BlockGroup(null, new ArrayList<Block>());
+          BlockGroup newBlockGroup = new BlockGroup(null, new ArrayList<>());
           newBlockGroup.blocks.add(block);
           blockGroups.add(newBlockGroup);
         }
@@ -1318,15 +1318,15 @@ public interface Fragment {
         return escape(text);
       }
 
-      Map<Integer, List<Span>> tagsStart = new HashMap<Integer, List<Span>>();
-      Map<Integer, List<Span>> tagsEnd = new HashMap<Integer, List<Span>>();
+      Map<Integer, List<Span>> tagsStart = new HashMap<>();
+      Map<Integer, List<Span>> tagsEnd = new HashMap<>();
 
       for (Span span: spans) {
         if (!tagsStart.containsKey(span.getStart())) {
-          tagsStart.put(span.getStart(), new ArrayList<Span>());
+          tagsStart.put(span.getStart(), new ArrayList<>());
         }
         if (!tagsEnd.containsKey(span.getEnd())) {
-          tagsEnd.put(span.getEnd(), new ArrayList<Span>());
+          tagsEnd.put(span.getEnd(), new ArrayList<>());
         }
         tagsStart.get(span.getStart()).add(span);
         tagsEnd.get(span.getEnd()).add(span);
@@ -1334,7 +1334,7 @@ public interface Fragment {
 
       char c;
       String html = "";
-      Stack<Tuple<Span, String>> stack = new Stack<Tuple<Span, String>>();
+      Stack<Tuple<Span, String>> stack = new Stack<>();
       for (int pos = 0, len = text.length(); pos < len; pos++) {
         if (tagsEnd.containsKey(pos)) {
           for (Span span: tagsEnd.get(pos)) {
@@ -1347,14 +1347,14 @@ public interface Fragment {
             } else {
               // Add the content to the parent tag
               Tuple<Span, String> head = stack.pop();
-              stack.push(new Tuple<Span, String>(head.x, head.y + innerHtml));
+              stack.push(new Tuple<>(head.x, head.y + innerHtml));
             }
           }
         }
         if (tagsStart.containsKey(pos)) {
           for (Span span: tagsStart.get(pos)) {
             // Open a tag
-            stack.push(new Tuple<Span, String>(span, ""));
+            stack.push(new Tuple<>(span, ""));
           }
         }
         c = text.charAt(pos);
@@ -1365,7 +1365,7 @@ public interface Fragment {
         } else {
           // Inner text of a span
           Tuple<Span, String> head = stack.pop();
-          stack.push(new Tuple<Span, String>(head.x, head.y + escaped));
+          stack.push(new Tuple<>(head.x, head.y + escaped));
         }
       }
       // Close remaining tags
@@ -1378,7 +1378,7 @@ public interface Fragment {
         } else {
           // Add the content to the parent tag
           Tuple<Span, String> head = stack.pop();
-          stack.push(new Tuple<Span, String>(head.x, head.y + innerHtml));
+          stack.push(new Tuple<>(head.x, head.y + innerHtml));
         }
       }
       return html;
@@ -1461,7 +1461,7 @@ public interface Fragment {
 
     public static ParsedText parseText(JsonNode json) {
       String text = json.path("text").asText();
-      List<Span> spans = new ArrayList<Span>();
+      List<Span> spans = new ArrayList<>();
       for(JsonNode spanJson: json.withArray("spans")) {
         Span span = parseSpan(spanJson);
         if(span != null) {
@@ -1508,7 +1508,7 @@ public interface Fragment {
     }
 
     public static StructuredText parse(JsonNode json) {
-      List<Block> blocks = new ArrayList<Block>();
+      List<Block> blocks = new ArrayList<>();
       for(JsonNode blockJson: json) {
         Block block = parseBlock(blockJson);
         if(block != null) {
@@ -1543,7 +1543,7 @@ public interface Fragment {
      */
     @Deprecated
     public List<Map<String, Fragment>> toMapList() {
-      List<Map<String, Fragment>> result = new ArrayList<Map<String, Fragment>>();
+      List<Map<String, Fragment>> result = new ArrayList<>();
       for (GroupDoc groupDoc: this.groupDocs) {
         result.add(groupDoc.getFragments());
       }
@@ -1567,7 +1567,7 @@ public interface Fragment {
      * @return the properly initialized Fragment.Group object
      */
     public static Group parse(JsonNode json) {
-      List<GroupDoc> groupDocs = new ArrayList<GroupDoc>();
+      List<GroupDoc> groupDocs = new ArrayList<>();
       for(JsonNode groupJson : json) {
         groupDocs.add(parseGroupDoc(groupJson));
       }
@@ -1583,7 +1583,7 @@ public interface Fragment {
     public static GroupDoc parseGroupDoc(JsonNode groupJson) {
       // each groupJson looks like this: { "somelink" : { "type" : "Link.document", { ... } }, "someimage" : { ... } }
       Iterator<String> dataJson = groupJson.fieldNames();
-      Map<String, Fragment> fragmentMap = new LinkedHashMap<String, Fragment>();
+      Map<String, Fragment> fragmentMap = new LinkedHashMap<>();
       while (dataJson.hasNext()) {
         String field = dataJson.next();
         JsonNode fieldJson = groupJson.path(field);

--- a/src/main/java/io/prismic/Fragment.java
+++ b/src/main/java/io/prismic/Fragment.java
@@ -19,7 +19,7 @@ public interface Fragment {
   /**
    * The Text type, represents a plain text
    */
-  public static class Text implements Fragment {
+  class Text implements Fragment {
     private final String value;
 
     public Text(String value) {
@@ -47,7 +47,7 @@ public interface Fragment {
   /**
    * A Date fragment. For date and time, see Timestamp.
    */
-  public static class Date implements Fragment {
+  class Date implements Fragment {
     private final LocalDate value;
 
     public Date(LocalDate value) {
@@ -83,7 +83,7 @@ public interface Fragment {
   /**
    * Timestamp fragment: date with time. For just date, see Date.
    */
-  public static class Timestamp implements Fragment {
+  class Timestamp implements Fragment {
     private final DateTime value;
 
     public Timestamp(DateTime value) {
@@ -121,7 +121,7 @@ public interface Fragment {
   /**
    * A Number fragment. Represented by a Double.
    */
-  public static class Number implements Fragment {
+  class Number implements Fragment {
     private final Double value;
 
     public Number(Double value) {
@@ -157,7 +157,7 @@ public interface Fragment {
   /**
    * A CSS color, represented by its hexadecimal representation (ex: #FF0000)
    */
-  public static class Color implements Fragment {
+  class Color implements Fragment {
     private final String hex;
 
     public Color(String hex) {
@@ -189,7 +189,7 @@ public interface Fragment {
   /**
    * A geographical point fragment, represented by longitude and latitude
    */
-  public static class GeoPoint implements Fragment {
+  class GeoPoint implements Fragment {
 
     private final Double latitude;
     private final Double longitude;
@@ -226,7 +226,7 @@ public interface Fragment {
   /**
    * An embeded object, typically coming from a third party service (example: YouTube video)
    */
-  public static class Embed implements Fragment {
+  class Embed implements Fragment {
     private final String type;
     private final String provider;
     private final String url;
@@ -301,23 +301,23 @@ public interface Fragment {
   /**
    * A Link fragment
    */
-  public static interface Link extends Fragment {
+  interface Link extends Fragment {
     /**
      * Return the target URL of the link. For WebLink the URL is directly received from
      * Prismic, for DocumentLink it is generated from the resolver you pass.
      * @param resolver DocumentLinkResolver, only used for DocumentLink.
      * @return target URL of the link
      */
-    public String getUrl(LinkResolver resolver);
+    String getUrl(LinkResolver resolver);
 
     /**
      * Return the target of the link.
      * @return target of the link
      */
-    public String getTarget();
+    String getTarget();
   }
 
-  public static class WebLink implements Link {
+  class WebLink implements Link {
     private final String url;
     private final String contentType;
     private final String target;
@@ -368,7 +368,7 @@ public interface Fragment {
   /**
    * Link to a file uploaded to Prismic's Media Library, for example a PDF file.
    */
-  public static class FileLink implements Link {
+  class FileLink implements Link {
     private final String url;
     private final String kind;
     private final Long size;
@@ -429,7 +429,7 @@ public interface Fragment {
   /**
    * Link to an image uploaded to Prismic's Media Library
    */
-  public static class ImageLink implements Link {
+  class ImageLink implements Link {
     private final String url;
 
     public ImageLink(String url) {
@@ -463,7 +463,7 @@ public interface Fragment {
    * but for Prismic to return any fragment you need to use the fetchLink parameter
    * when querying your repository.
    */
-  public static class DocumentLink extends WithFragments implements Link {
+  class DocumentLink extends WithFragments implements Link {
     private final String id;
     private final String uid;
     private final String type;
@@ -562,7 +562,7 @@ public interface Fragment {
    * An image fragment. Image are composed of several views that correspond to different sizes
    * of the same image.
    */
-  public static class Image implements Fragment {
+  class Image implements Fragment {
 
     /**
      * A View is a representation of an image at a specific size
@@ -618,7 +618,7 @@ public interface Fragment {
           String target = "";
           if (this.linkTo instanceof WebLink) {
             url = ((WebLink) this.linkTo).getUrl();
-            String webTarget = ((WebLink) this.linkTo).getTarget();
+            String webTarget = this.linkTo.getTarget();
             target = webTarget != null ? " target=\"" + webTarget + "\" rel=\"noopener\"" : "";
           } else if (this.linkTo instanceof ImageLink) {
             url = ((ImageLink) this.linkTo).getUrl();
@@ -712,16 +712,16 @@ public interface Fragment {
   /**
    * A generic Slice fragment
    */
-  public interface Slice {
+  interface Slice {
 
-    public String getSliceType();
-    public String getLabel();
+    String getSliceType();
+    String getLabel();
   }
 
   /**
    * The Composite Slice
    */
-  public static class CompositeSlice implements Slice {
+  class CompositeSlice implements Slice {
     private final String sliceType;
     private final String label;
     private final Group repeat;
@@ -766,7 +766,7 @@ public interface Fragment {
    * @deprecated use CompositeSlice instead
    */
   @Deprecated
-  public static class SimpleSlice implements Slice {
+  class SimpleSlice implements Slice {
     private final String sliceType;
     private final String label;
     private final Fragment value;
@@ -798,7 +798,7 @@ public interface Fragment {
     }
   }
 
-  public static class SliceZone implements Fragment {
+  class SliceZone implements Fragment {
     private final List<Slice> slices;
 
     public SliceZone(List<Slice> slices) {
@@ -848,20 +848,20 @@ public interface Fragment {
    * A Structured text, typically a text including blocks, formatting, links, images... As created
    * in the Writing Room.
    */
-  public static class StructuredText implements Fragment {
+  class StructuredText implements Fragment {
 
-    public static interface Element {}
+    public interface Element {}
 
-    public static interface Block extends Element {
+    public interface Block extends Element {
 
-      public String getLabel();
+      String getLabel();
 
-      public static interface Text extends Block {
-        public String getText();
-        public List<Span> getSpans();
+      interface Text extends Block {
+        String getText();
+        List<Span> getSpans();
       }
 
-      public static class Heading implements Text {
+      class Heading implements Text {
         private final String text;
         private final List<Span> spans;
         private final int level;
@@ -892,7 +892,7 @@ public interface Fragment {
 
       }
 
-      public static class Paragraph implements Text {
+      class Paragraph implements Text {
         private final String text;
         private final List<Span> spans;
         private final String label;
@@ -914,7 +914,7 @@ public interface Fragment {
         public String getLabel() { return label; }
       }
 
-      public static class Preformatted implements Text {
+      class Preformatted implements Text {
         private final String text;
         private final List<Span> spans;
         private final String label;
@@ -941,7 +941,7 @@ public interface Fragment {
       /**
        * A listitem, typically a "li" tag within a "ul" or "ol" (whether the ordered property is true or not)
        */
-      public static class ListItem implements Text {
+      class ListItem implements Text {
         private final String text;
         private final List<Span> spans;
         private final boolean ordered;
@@ -974,7 +974,7 @@ public interface Fragment {
       /**
        * An image within a StructuredText
        */
-      public static class Image implements Block {
+      class Image implements Block {
         private final Fragment.Image.View view;
         private final String label;
 
@@ -1007,7 +1007,7 @@ public interface Fragment {
       /**
        * An embed within a StructuredText
        */
-      public static class Embed implements Block {
+      class Embed implements Block {
         private final Fragment.Embed obj;
         private final String label;
 
@@ -1027,11 +1027,11 @@ public interface Fragment {
 
     }
 
-    public static interface Span extends Element {
-      public int getStart();
-      public int getEnd();
+    public interface Span extends Element {
+      int getStart();
+      int getEnd();
 
-      public static class Em implements Span {
+      class Em implements Span {
         private final int start;
         private final int end;
 
@@ -1049,7 +1049,7 @@ public interface Fragment {
         }
       }
 
-      public static class Strong implements Span {
+      class Strong implements Span {
         private final int start;
         private final int end;
 
@@ -1067,7 +1067,7 @@ public interface Fragment {
         }
       }
 
-      public static class Hyperlink implements Span {
+      class Hyperlink implements Span {
         private final int start;
         private final int end;
         private final Link link;
@@ -1091,7 +1091,7 @@ public interface Fragment {
         }
       }
 
-      public static class Label implements Span {
+      class Label implements Span {
         private final int start;
         private final int end;
         private final String label;
@@ -1523,7 +1523,7 @@ public interface Fragment {
   /**
    * Represents a Group fragment.
    */
-  public static class Group implements Fragment {
+  class Group implements Fragment {
     private final List<GroupDoc> groupDocs;
 
     public Group(List<GroupDoc> groupDocs) {

--- a/src/main/java/io/prismic/Fragment.java
+++ b/src/main/java/io/prismic/Fragment.java
@@ -1,13 +1,14 @@
 package io.prismic;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+
 import java.util.*;
-import java.util.regex.Pattern;
 import java.util.regex.Matcher;
-
-import org.joda.time.*;
-import org.joda.time.format.*;
-
-import com.fasterxml.jackson.databind.*;
+import java.util.regex.Pattern;
 
 /**
  * A generic fragment of document

--- a/src/main/java/io/prismic/Fragment.java
+++ b/src/main/java/io/prismic/Fragment.java
@@ -1589,7 +1589,7 @@ public interface Fragment {
         String fragmentType = fieldJson.path("type").asText();
         JsonNode fragmentValue = fieldJson.path("value");
         Fragment fragment = Document.parseFragment(fragmentType, fragmentValue);
-        if (fragment != null) fragmentMap.put(field, fragment);
+        fragmentMap.put(field, fragment);
       }
       return new GroupDoc(fragmentMap);
     }

--- a/src/main/java/io/prismic/Fragment.java
+++ b/src/main/java/io/prismic/Fragment.java
@@ -309,7 +309,7 @@ public interface Fragment {
      * @return target URL of the link
      */
     public String getUrl(LinkResolver resolver);
-    
+
     /**
      * Return the target of the link.
      * @return target of the link
@@ -763,8 +763,9 @@ public interface Fragment {
   }
 
   /**
-   * The depricated Simple Slice
+   * @deprecated use CompositeSlice instead
    */
+  @Deprecated
   public static class SimpleSlice implements Slice {
     private final String sliceType;
     private final String label;

--- a/src/main/java/io/prismic/Fragment.java
+++ b/src/main/java/io/prismic/Fragment.java
@@ -105,7 +105,7 @@ public interface Fragment {
 
     // --
 
-    private static DateTimeFormatter isoFormat = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ssZ");
+    private static final DateTimeFormatter isoFormat = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ssZ");
 
     public static Timestamp parse(JsonNode json) {
       try {

--- a/src/main/java/io/prismic/HtmlSerializer.java
+++ b/src/main/java/io/prismic/HtmlSerializer.java
@@ -6,6 +6,6 @@ package io.prismic;
  */
 public interface HtmlSerializer {
 
-    public abstract String serialize(Fragment.StructuredText.Element element, String content);
+    String serialize(Fragment.StructuredText.Element element, String content);
 
 }

--- a/src/main/java/io/prismic/LinkResolver.java
+++ b/src/main/java/io/prismic/LinkResolver.java
@@ -4,6 +4,8 @@ public interface LinkResolver {
 
   public String resolve(Fragment.DocumentLink link);
 
-  public String resolve(Document document);
+  public default String resolve(Document document) {
+    return resolve(document.asDocumentLink());
+  }
 
 }

--- a/src/main/java/io/prismic/LinkResolver.java
+++ b/src/main/java/io/prismic/LinkResolver.java
@@ -2,9 +2,9 @@ package io.prismic;
 
 public interface LinkResolver {
 
-  public String resolve(Fragment.DocumentLink link);
+  String resolve(Fragment.DocumentLink link);
 
-  public default String resolve(Document document) {
+  default String resolve(Document document) {
     return resolve(document.asDocumentLink());
   }
 

--- a/src/main/java/io/prismic/Logger.java
+++ b/src/main/java/io/prismic/Logger.java
@@ -2,11 +2,11 @@ package io.prismic;
 
 public interface Logger {
 
-  public void log(String level, String message);
+  void log(String level, String message);
 
-  // -- 
+  // --
 
-  public static class NoLogger implements Logger {
+  class NoLogger implements Logger {
 
     public void log(String level, String message) {
     }
@@ -15,7 +15,7 @@ public interface Logger {
 
   // --
 
-  public static class PrintlnLogger implements Logger {
+  class PrintlnLogger implements Logger {
 
     public void log(String level, String message) {
       System.out.println("[prismic." + level + "] " + message);

--- a/src/main/java/io/prismic/Main.java
+++ b/src/main/java/io/prismic/Main.java
@@ -1,6 +1,6 @@
 package io.prismic;
 
-import java.util.*;
+import java.util.List;
 
 public class Main {
 
@@ -31,5 +31,5 @@ public class Main {
 
     System.out.println("DONE.");
   }
-  
+
 }

--- a/src/main/java/io/prismic/Predicate.java
+++ b/src/main/java/io/prismic/Predicate.java
@@ -2,6 +2,6 @@ package io.prismic;
 
 public interface Predicate {
 
-  public String q();
+  String q();
 
 }

--- a/src/main/java/io/prismic/Predicates.java
+++ b/src/main/java/io/prismic/Predicates.java
@@ -2,8 +2,6 @@ package io.prismic;
 
 import org.joda.time.DateTime;
 
-import java.util.List;
-
 public class Predicates {
 
   public enum DayOfWeek {

--- a/src/main/java/io/prismic/Ref.java
+++ b/src/main/java/io/prismic/Ref.java
@@ -1,8 +1,7 @@
 package io.prismic;
 
-import org.joda.time.*;
-
-import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.joda.time.DateTime;
 
 public class Ref {
 

--- a/src/main/java/io/prismic/Response.java
+++ b/src/main/java/io/prismic/Response.java
@@ -1,8 +1,10 @@
 package io.prismic;
 
-import java.util.*;
+import com.fasterxml.jackson.databind.JsonNode;
 
-import com.fasterxml.jackson.databind.*;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 
 public class Response {
 

--- a/src/main/java/io/prismic/Response.java
+++ b/src/main/java/io/prismic/Response.java
@@ -49,7 +49,7 @@ public class Response {
   static Response parse(JsonNode json) {
     Iterator<JsonNode> resultsJson = null;
     resultsJson = json.path("results").elements();
-    List<Document> results = new ArrayList<Document>();
+    List<Document> results = new ArrayList<>();
     while (resultsJson.hasNext()) {
       results.add(Document.parse(resultsJson.next()));
     }

--- a/src/main/java/io/prismic/Response.java
+++ b/src/main/java/io/prismic/Response.java
@@ -49,7 +49,7 @@ public class Response {
   }
 
   static Response parse(JsonNode json) {
-    Iterator<JsonNode> resultsJson = null;
+    Iterator<JsonNode> resultsJson;
     resultsJson = json.path("results").elements();
     List<Document> results = new ArrayList<>();
     while (resultsJson.hasNext()) {

--- a/src/main/java/io/prismic/SimpleLinkResolver.java
+++ b/src/main/java/io/prismic/SimpleLinkResolver.java
@@ -1,9 +1,16 @@
 package io.prismic;
 
+/**
+ * @deprecated as of 2.0 {@link LinkResolver} has default methods (made
+ * possible by a Java 8 baseline) and can be implemented directly without the
+ * need for this adapter
+ */
+@Deprecated
 public abstract class SimpleLinkResolver implements LinkResolver {
 
   public abstract String resolve(Fragment.DocumentLink link);
 
+  @Override
   public String resolve(Document document) {
     return resolve(document.asDocumentLink());
   }

--- a/src/main/java/io/prismic/SimplePredicate.java
+++ b/src/main/java/io/prismic/SimplePredicate.java
@@ -2,9 +2,6 @@ package io.prismic;
 
 import org.joda.time.DateTime;
 
-import java.util.Iterator;
-import java.util.List;
-
 class SimplePredicate implements Predicate {
 
   private final String name;

--- a/src/main/java/io/prismic/SimplePredicate.java
+++ b/src/main/java/io/prismic/SimplePredicate.java
@@ -47,7 +47,7 @@ class SimplePredicate implements Predicate {
 
   private static String serializeField(Object value) {
     if (value instanceof Iterable) {
-      return "[" + join((Iterable)value, ",") + "]";
+      return "[" + join((Iterable)value) + "]";
     } else if (value instanceof Predicates.Month) {
       return ("\"" + capitalize(((Predicates.Month) value).name()) + "\"");
     } else if (value instanceof Predicates.DayOfWeek) {
@@ -61,7 +61,7 @@ class SimplePredicate implements Predicate {
     }
   }
 
-  private static <T> String join(Iterable<T> elements, String sep) {
+  private static <T> String join(Iterable<T> elements) {
     if (!elements.iterator().hasNext()) return "";
     StringBuilder result = new StringBuilder();
     boolean first = true;
@@ -69,7 +69,7 @@ class SimplePredicate implements Predicate {
       if (first) {
         first = false;
       } else {
-        result.append(sep);
+        result.append(",");
       }
       result.append("\"").append(elt).append("\"");
     }

--- a/src/main/java/io/prismic/WithFragments.java
+++ b/src/main/java/io/prismic/WithFragments.java
@@ -288,7 +288,7 @@ public abstract class WithFragments {
   public String asHtml(LinkResolver linkResolver, HtmlSerializer htmlSerializer) {
     StringBuilder html = new StringBuilder();
     for(Map.Entry<String,Fragment> fragment: getFragments().entrySet()) {
-      html.append("<section data-field=\"" + fragment.getKey() + "\">");
+      html.append("<section data-field=\"").append(fragment.getKey()).append("\">");
       html.append(getHtml(fragment.getKey(), linkResolver, htmlSerializer));
       html.append("</section>\n");
     }

--- a/src/main/java/io/prismic/WithFragments.java
+++ b/src/main/java/io/prismic/WithFragments.java
@@ -276,9 +276,7 @@ public abstract class WithFragments {
     Fragment fragment = get(field);
     if(fragment != null && fragment instanceof Fragment.Text) {
       String value = ((Fragment.Text)fragment).getValue().toLowerCase();
-      if("yes".equals(value) || "true".equals(value)) {
-        return true;
-      }
+      return "yes".equals(value) || "true".equals(value);
     }
     return false;
   }

--- a/src/main/java/io/prismic/WithFragments.java
+++ b/src/main/java/io/prismic/WithFragments.java
@@ -9,7 +9,7 @@ public abstract class WithFragments {
   public abstract Map<String, Fragment> getFragments();
 
   public List<Fragment.DocumentLink> getLinkedDocuments() {
-    List<Fragment.DocumentLink> result = new ArrayList<Fragment.DocumentLink>();
+    List<Fragment.DocumentLink> result = new ArrayList<>();
     for (Fragment fragment: getFragments().values()) {
       if (fragment instanceof Fragment.DocumentLink) {
         result.add((Fragment.DocumentLink)fragment);
@@ -51,7 +51,7 @@ public abstract class WithFragments {
   }
 
   public List<Fragment> getAll(String field) {
-    List<Fragment> result = new ArrayList<Fragment>();
+    List<Fragment> result = new ArrayList<>();
     for(Map.Entry<String,Fragment> entry: getFragments().entrySet()) {
       if(entry.getKey().matches("\\Q" + field + "\\E\\[\\d+\\]")) {
         result.add(entry.getValue());
@@ -77,7 +77,7 @@ public abstract class WithFragments {
 
   public List<Fragment.Image> getAllImages(String field) {
     List<Fragment> fragments = getAll(field);
-    List<Fragment.Image> images = new ArrayList<Fragment.Image>();
+    List<Fragment.Image> images = new ArrayList<>();
     for(Fragment fragment: fragments) {
       if(fragment != null && fragment instanceof Fragment.Image) {
         images.add((Fragment.Image)fragment);
@@ -102,7 +102,7 @@ public abstract class WithFragments {
   }
 
   public List<Fragment.Image.View> getAllImages(String field, String view) {
-    List<Fragment.Image.View> views = new ArrayList<Fragment.Image.View>();
+    List<Fragment.Image.View> views = new ArrayList<>();
     for (Fragment.Image image: getAllImages(field)) {
       Fragment.Image.View imageView = image.getView(view);
       if (imageView != null) {

--- a/src/main/java/io/prismic/core/HttpClient.java
+++ b/src/main/java/io/prismic/core/HttpClient.java
@@ -53,7 +53,7 @@ public class HttpClient {
           throw new Api.Error(Api.Error.Code.UNEXPECTED, httpConnection.getResponseCode() + " (" + body + ")");
         }
       } catch (MalformedURLException e) {
-        throw new Api.Error(Api.Error.Code.MALFORMED_URL, e.getMessage());
+        throw new Api.Error(Api.Error.Code.MALFORMED_URL, e);
       } catch (IOException e) {
         String body;
         String errorText = "Unknown error";
@@ -77,7 +77,7 @@ public class HttpClient {
         }
       }
     } catch(IOException e) {
-      throw new Api.Error(Api.Error.Code.UNEXPECTED, e.getMessage());
+      throw new Api.Error(Api.Error.Code.UNEXPECTED, e);
     }
   }
 
@@ -85,7 +85,7 @@ public class HttpClient {
     try {
       return URLEncoder.encode(str, "utf-8");
     } catch(Exception e) {
-      throw new Api.Error(Api.Error.Code.UNEXPECTED, e.getMessage());
+      throw new Api.Error(Api.Error.Code.UNEXPECTED, e);
     }
   }
 

--- a/src/main/java/io/prismic/core/HttpClient.java
+++ b/src/main/java/io/prismic/core/HttpClient.java
@@ -16,8 +16,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 public class HttpClient {
 
   public static JsonNode fetch(String url, Logger logger, Cache cache, Proxy proxy) {
-    logger = (logger!=null) ? logger : new Logger.NoLogger();
-    cache = (cache!=null) ? cache : new Cache.NoCache();
+    logger = (logger != null) ? logger : new Logger.NoLogger();
+    cache = (cache != null) ? cache : new Cache.NoCache();
     try {
       JsonNode cachedResult = cache.get(url);
       if (cachedResult != null) {
@@ -61,7 +61,7 @@ public class HttpClient {
         if (errorJson != null) {
           errorText = errorJson.get("error").asText();
         }
-        switch(httpConnection.getResponseCode()) {
+        switch (httpConnection.getResponseCode()) {
           case 401:
             if ("Invalid access token".equals(errorText)) {
               throw new Api.Error(Api.Error.Code.INVALID_TOKEN, errorText);
@@ -73,10 +73,10 @@ public class HttpClient {
             throw new Api.Error(Api.Error.Code.TOO_MANY_REQUESTS, "[429] " + body);
           default:
             body = (response != null) ? IOUtils.toString(response, UTF_8) : "";
-            throw new RuntimeException("HTTP error " + httpConnection.getResponseCode() + " (" + body + ")");
+            throw new Api.Error(Api.Error.Code.UNEXPECTED, "HTTP error " + httpConnection.getResponseCode() + " (" + body + ")");
         }
       }
-    } catch(IOException e) {
+    } catch (IOException e) {
       throw new Api.Error(Api.Error.Code.UNEXPECTED, e);
     }
   }
@@ -84,7 +84,7 @@ public class HttpClient {
   public static String encodeURIComponent(String str) {
     try {
       return URLEncoder.encode(str, "utf-8");
-    } catch(Exception e) {
+    } catch (Exception e) {
       throw new Api.Error(Api.Error.Code.UNEXPECTED, e);
     }
   }

--- a/src/main/java/io/prismic/core/HttpClient.java
+++ b/src/main/java/io/prismic/core/HttpClient.java
@@ -11,6 +11,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.*;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 public class HttpClient {
 
   public static JsonNode fetch(String url, Logger logger, Cache cache, Proxy proxy) {
@@ -47,7 +49,7 @@ public class HttpClient {
           }
           return value;
         } else {
-          String body = (response != null) ? IOUtils.toString(response) : "";
+          String body = (response != null) ? IOUtils.toString(response, UTF_8) : "";
           throw new Api.Error(Api.Error.Code.UNEXPECTED, httpConnection.getResponseCode() + " (" + body + ")");
         }
       } catch (MalformedURLException e) {
@@ -71,10 +73,10 @@ public class HttpClient {
               throw new Api.Error(Api.Error.Code.AUTHORIZATION_NEEDED, errorText);
             }
           case 429:
-            body = (response != null) ? IOUtils.toString(response) : "";
+            body = (response != null) ? IOUtils.toString(response, UTF_8) : "";
             throw new Api.Error(Api.Error.Code.TOO_MANY_REQUESTS, "[429] " + body);
           default:
-            body = (response != null) ? IOUtils.toString(response) : "";
+            body = (response != null) ? IOUtils.toString(response, UTF_8) : "";
             throw new RuntimeException("HTTP error " + httpConnection.getResponseCode() + " (" + body + ")");
         }
       }

--- a/src/main/java/io/prismic/core/HttpClient.java
+++ b/src/main/java/io/prismic/core/HttpClient.java
@@ -1,13 +1,15 @@
 package io.prismic.core;
 
-import java.io.*;
-import java.net.*;
-
-import io.prismic.*;
-
-import com.fasterxml.jackson.databind.*;
-
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.prismic.Api;
+import io.prismic.Cache;
+import io.prismic.Logger;
 import org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.*;
 
 public class HttpClient {
 

--- a/src/main/java/io/prismic/core/HttpClient.java
+++ b/src/main/java/io/prismic/core/HttpClient.java
@@ -80,8 +80,6 @@ public class HttpClient {
             throw new RuntimeException("HTTP error " + httpConnection.getResponseCode() + " (" + body + ")");
         }
       }
-    } catch(Api.Error e) {
-      throw e;
     } catch(IOException e) {
       e.printStackTrace();
       throw new Api.Error(Api.Error.Code.UNEXPECTED, e.getMessage());

--- a/src/main/java/io/prismic/core/HttpClient.java
+++ b/src/main/java/io/prismic/core/HttpClient.java
@@ -57,13 +57,9 @@ public class HttpClient {
       } catch (IOException e) {
         String body;
         String errorText = "Unknown error";
-        try {
-          JsonNode errorJson = new ObjectMapper().readTree(httpConnection.getErrorStream());
-          if (errorJson != null) {
-            errorText = errorJson.get("error").asText();
-          }
-        } catch (Exception ex) {
-          ex.printStackTrace();
+        JsonNode errorJson = new ObjectMapper().readTree(httpConnection.getErrorStream());
+        if (errorJson != null) {
+          errorText = errorJson.get("error").asText();
         }
         switch(httpConnection.getResponseCode()) {
           case 401:
@@ -81,7 +77,6 @@ public class HttpClient {
         }
       }
     } catch(IOException e) {
-      e.printStackTrace();
       throw new Api.Error(Api.Error.Code.UNEXPECTED, e.getMessage());
     }
   }

--- a/src/main/java/io/prismic/servlet/PrismicFilter.java
+++ b/src/main/java/io/prismic/servlet/PrismicFilter.java
@@ -1,18 +1,13 @@
 package io.prismic.servlet;
 
-import io.prismic.*;
+import io.prismic.Api;
+import io.prismic.Prismic;
 
-import java.io.IOException;
-
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
+import javax.servlet.*;
 import javax.servlet.annotation.WebFilter;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
 
 /*
  * WebFilter for JEE applications.

--- a/src/main/java/io/prismic/servlet/PrismicFilter.java
+++ b/src/main/java/io/prismic/servlet/PrismicFilter.java
@@ -27,7 +27,7 @@ public class PrismicFilter implements Filter {
 	private String accessToken;
 
 	@Override
-	public void init(FilterConfig filterConfig) throws ServletException {
+	public void init(FilterConfig filterConfig) {
     endpoint = filterConfig.getInitParameter("endpoint");
     accessToken = filterConfig.getInitParameter("accessToken");
 	}

--- a/src/test/java/io/prismic/AppTest.java
+++ b/src/test/java/io/prismic/AppTest.java
@@ -4,7 +4,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -320,7 +320,7 @@ public class AppTest {
   //       16
   //     );
   // }
-  
+
   @Test
 	public void proxySupportOk() throws UnknownHostException {
 		ProxySpyHttpFiltersSource proxySpy = new ProxySpyHttpFiltersSource();
@@ -361,5 +361,5 @@ public class AppTest {
 		}
 	}
 
-  
+
 }

--- a/src/test/java/io/prismic/AppTest.java
+++ b/src/test/java/io/prismic/AppTest.java
@@ -5,7 +5,6 @@ import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import org.junit.Assert;
-
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.littleshoot.proxy.HttpFilters;
@@ -18,8 +17,6 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.UnknownHostException;
-import java.util.List;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**

--- a/src/test/java/io/prismic/CacheTest.java
+++ b/src/test/java/io/prismic/CacheTest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import io.prismic.Cache.BuiltInCache;
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 

--- a/src/test/java/io/prismic/CacheTest.java
+++ b/src/test/java/io/prismic/CacheTest.java
@@ -45,7 +45,7 @@ public class CacheTest
     }
 
     @Test
-    public void testFullCache() throws InterruptedException {
+    public void testFullCache() {
         Cache cache = fullCache;
         cache.set("/bar/1", TTL, defaultValue());
         Assert.assertEquals("Full cache should accept new entries", cache.get("/bar/1"), defaultValue());

--- a/src/test/java/io/prismic/CacheTest.java
+++ b/src/test/java/io/prismic/CacheTest.java
@@ -1,8 +1,8 @@
 package io.prismic;
 
-import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import io.prismic.Cache.BuiltInCache;
 import org.junit.Assert;
 import org.junit.BeforeClass;

--- a/src/test/java/io/prismic/DocumentTest.java
+++ b/src/test/java/io/prismic/DocumentTest.java
@@ -2,9 +2,9 @@ package io.prismic;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;

--- a/src/test/java/io/prismic/DocumentTest.java
+++ b/src/test/java/io/prismic/DocumentTest.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 public class DocumentTest {
 
-  final LinkResolver linkResolver = new SimpleLinkResolver() {
+  private final LinkResolver linkResolver = new SimpleLinkResolver() {
     public String resolve(Fragment.DocumentLink link) {
       return "/"+link.getId()+"/"+link.getSlug();
     }
@@ -272,6 +272,30 @@ public class DocumentTest {
     Assert.assertEquals(
       "<p>Line<br/>with<br/><br/>line breaks</p>",
       text.asHtml(linkResolver)
+    );
+  }
+
+  @Test
+  public void fragmentWithNoType() throws Exception {
+    ObjectMapper mapper = new ObjectMapper();
+    String jsonString = "{ \"value\": { \"id\": \"5708520413001\", \"data\": { \"key1\": \"value1\", \"key2\": \"value2\" }, \"an_integer\": 123456789 } }";
+    JsonNode json = mapper.readTree(jsonString);
+    Fragment.Raw raw = Fragment.Raw.parse(json.path("value"));
+    Assert.assertEquals(
+      "{\"id\":\"5708520413001\",\"data\":{\"key1\":\"value1\",\"key2\":\"value2\"},\"an_integer\":123456789}",
+      raw.asText()
+    );
+  }
+
+  @Test
+  public void fragmentWithUnknownType() throws Exception {
+    ObjectMapper mapper = new ObjectMapper();
+    String jsonString = "{ \"type\": \"Unknown\", \"value\": { \"id\": \"5708520413001\", \"data\": { \"key1\": \"value1\", \"key2\": \"value2\" }, \"an_integer\": 123456789 } }";
+    JsonNode json = mapper.readTree(jsonString);
+    Fragment.Raw raw = Fragment.Raw.parse(json.path("value"));
+    Assert.assertEquals(
+      "{\"id\":\"5708520413001\",\"data\":{\"key1\":\"value1\",\"key2\":\"value2\"},\"an_integer\":123456789}",
+      raw.asText()
     );
   }
 

--- a/src/test/java/io/prismic/DocumentTest.java
+++ b/src/test/java/io/prismic/DocumentTest.java
@@ -2,7 +2,7 @@ package io.prismic;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Test;
@@ -30,12 +30,12 @@ public class DocumentTest {
     Assert.assertEquals(
       "The geopoint latitude retrieval work well",
       doc.getGeoPoint("store.coordinates").getLatitude(),
-      48.877108d
+      Double.valueOf(48.877108d)
     );
     Assert.assertEquals(
       "The geopoint longitude retrieval work well",
       doc.getGeoPoint("store.coordinates").getLongitude(),
-      2.3338790d
+      Double.valueOf(2.3338790d)
     );
   }
 

--- a/src/test/java/io/prismic/DocumentTest.java
+++ b/src/test/java/io/prismic/DocumentTest.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 public class DocumentTest {
 
-  LinkResolver linkResolver = new SimpleLinkResolver() {
+  final LinkResolver linkResolver = new SimpleLinkResolver() {
     public String resolve(Fragment.DocumentLink link) {
       return "/"+link.getId()+"/"+link.getSlug();
     }

--- a/src/test/java/io/prismic/ErrorsTest.java
+++ b/src/test/java/io/prismic/ErrorsTest.java
@@ -1,9 +1,6 @@
 package io.prismic;
 
 
-import org.junit.Assert;
-import org.junit.Test;
-
 /**
  * Unit test for simple App.
  */

--- a/src/test/java/io/prismic/ErrorsTest.java
+++ b/src/test/java/io/prismic/ErrorsTest.java
@@ -1,7 +1,7 @@
 package io.prismic;
 
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 
 /**

--- a/src/test/java/io/prismic/ExperimentTest.java
+++ b/src/test/java/io/prismic/ExperimentTest.java
@@ -9,7 +9,7 @@ import java.io.IOException;
 
 public class ExperimentTest {
 
-  static String experimentsJson = "{"
+  static final String experimentsJson = "{"
       + "\"draft\": [{"
       + "\"id\": \"xxxxxxxxxxoGelsX\","
       + "\"name\": \"Exp 2\","

--- a/src/test/java/io/prismic/ExperimentTest.java
+++ b/src/test/java/io/prismic/ExperimentTest.java
@@ -2,7 +2,7 @@ package io.prismic;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;

--- a/src/test/java/io/prismic/PredicateTest.java
+++ b/src/test/java/io/prismic/PredicateTest.java
@@ -1,6 +1,6 @@
 package io.prismic;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;

--- a/src/test/java/io/prismic/PredicateTest.java
+++ b/src/test/java/io/prismic/PredicateTest.java
@@ -8,37 +8,37 @@ import java.util.Arrays;
 public class PredicateTest {
 
   @Test
-  public void testAtPredicate() throws Exception {
+  public void testAtPredicate() {
     Predicate p = Predicates.at("document.type", "blog-post");
     Assert.assertEquals("[:d = at(document.type, \"blog-post\")]", p.q());
   }
 
   @Test
-  public void testAnyPredicate() throws Exception {
+  public void testAnyPredicate() {
     Predicate p = Predicates.any("document.tags", Arrays.asList("Macaron", "Cupcakes"));
     Assert.assertEquals("[:d = any(document.tags, [\"Macaron\",\"Cupcakes\"])]", p.q());
   }
 
   @Test
-  public void testNumberLT() throws Exception {
+  public void testNumberLT() {
     Predicate p = Predicates.lt("my.product.price", 4.2);
     Assert.assertEquals("[:d = number.lt(my.product.price, 4.2)]", p.q());
   }
 
   @Test
-  public void testNumberInRange() throws Exception {
+  public void testNumberInRange() {
     Predicate p = Predicates.inRange("my.product.price", 2, 4);
     Assert.assertEquals("[:d = number.inRange(my.product.price, 2.0, 4.0)]", p.q());
   }
 
   @Test
-  public void testMonthAfter() throws Exception {
+  public void testMonthAfter() {
     Predicate p = Predicates.monthAfter("my.blog-post.publication-date", Predicates.Month.APRIL);
     Assert.assertEquals("[:d = date.month-after(my.blog-post.publication-date, \"April\")]", p.q());
   }
 
   @Test
-  public void testGeopointNear() throws Exception {
+  public void testGeopointNear() {
     Predicate p = Predicates.near("my.store.coordinates", 40.689757, -74.0451453, 15);
     Assert.assertEquals("[:d = geopoint.near(my.store.coordinates, 40.689757, -74.0451453, 15)]", p.q());
   }


### PR DESCRIPTION
Hello Prismic team,

The integration field feature is actually in beta, and we want to retrieve the data fetched from the integration field through the java-kit. But it is not possible right now because the fragment returned from the api has no `"type"` and then won't be parsed (the `parseFragment` method returns `null` when type is unknown).

This PR adds the support of the integration field (and any other unknown field) by parsing any unknown fragment to a `Raw` fragment which exposes the raw json as `JsonNode` (with `getValue` method) and as String (with `asText` method). 
When parsing a document, any unknown fragment will then be parsed as a `Raw` fragment instead of `null`. 

When a `"type"` will be added for integration field fragments, we willl be able to add a new specific fragment type in java-kit. But we will also keep the `Raw` fragment, which can handle any future unknown fragment.

This PR depends on #64 

Thanks!
