### PR TITLE
[enhancement] Replace callback with Java 8 Completable Future

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.prismic</groupId>
     <artifactId>java-kit</artifactId>
     <packaging>jar</packaging>
-    <version>2.0.0</version>
+    <version>2.1.0-SNAPSHOT</version>
     <name>java-kit</name>
     <description>The developer kit to access Prismic.io repositories using the Java language.</description>
     <url>http://maven.apache.org</url>

--- a/src/main/java/io/prismic/Api.java
+++ b/src/main/java/io/prismic/Api.java
@@ -8,6 +8,7 @@ import java.io.InputStream;
 import java.net.Proxy;
 import java.util.*;
 import java.util.Map.Entry;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Embodies an API endpoint, from which it is possible to make queries.
@@ -92,7 +93,7 @@ public class Api {
     JsonNode json = cache.getOrSet(
       url,
       5000L,
-      () -> HttpClient.fetch(url, logger, null, proxy)
+      CompletableFuture.supplyAsync(() -> HttpClient.fetch(url, logger, null, proxy))
     );
 
     ApiData apiData = ApiData.parse(json);

--- a/src/main/java/io/prismic/Callback.java
+++ b/src/main/java/io/prismic/Callback.java
@@ -1,5 +1,0 @@
-package io.prismic;
-
-public interface Callback {
-    void execute();
-}

--- a/src/test/java/io/prismic/AppTest.java
+++ b/src/test/java/io/prismic/AppTest.java
@@ -4,6 +4,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -51,9 +52,17 @@ public class AppTest {
   /**
    * Make sure a call to a private repository without a token returns the expected error
    */
-  @Test(expected = Api.Error.class)
+  @Test
   public void invalidToken() {
-    Api api = Api.get("https://private-test.prismic.io/api");
+    Throwable thrown = null;
+    try {
+      Api.get("https://private-test.prismic.io/api");
+    } catch (Throwable t) {
+      thrown = t;
+    }
+    Throwable rootCause = ExceptionUtils.getRootCause(thrown);
+    Assert.assertEquals(Api.Error.class, rootCause.getClass());
+    Assert.assertEquals("Invalid access token", rootCause.getMessage());
   }
 
   /**


### PR DESCRIPTION
Hi Prismic team!

Since Java 8, we can use the new `Future` reactive API (with `CompletableFuture`), to execute asynchronous callbacks instead of using a custom `Callback` interface.
This PR replaces the usage of the custom `Callback` interface by the standard Java 8 `Future` API.

