### PR TITLE
[bug] Fix NullPointerException when error stream does not contain error json field

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.prismic</groupId>
     <artifactId>java-kit</artifactId>
     <packaging>jar</packaging>
-    <version>2.0.0</version>
+    <version>2.0.1-SNAPSHOT</version>
     <name>java-kit</name>
     <description>The developer kit to access Prismic.io repositories using the Java language.</description>
     <url>http://maven.apache.org</url>

--- a/src/main/java/io/prismic/core/HttpClient.java
+++ b/src/main/java/io/prismic/core/HttpClient.java
@@ -58,7 +58,7 @@ public class HttpClient {
         String body;
         String errorText = "Unknown error";
         JsonNode errorJson = new ObjectMapper().readTree(httpConnection.getErrorStream());
-        if (errorJson != null) {
+        if (errorJson != null && errorJson.get("error") != null) {
           errorText = errorJson.get("error").asText();
         }
         switch (httpConnection.getResponseCode()) {

--- a/src/test/java/io/prismic/DocumentTest.java
+++ b/src/test/java/io/prismic/DocumentTest.java
@@ -170,7 +170,7 @@ public class DocumentTest {
          .query(Predicates.at("document.id", "Uyr9sgEAAGVHNoFZ"))
          .submit().getResults().get(0);
     Fragment.Image.View img =  doc.getImage("article.illustration", "icon");
-    String url = "https://prismic-io.s3.amazonaws.com/test-public/9f5f4e8a5d95c7259108e9cfdde953b5e60dcbb6.jpg";
+    String url = "https://test-public.cdn.prismic.io/test-public/9f5f4e8a5d95c7259108e9cfdde953b5e60dcbb6.jpg";
     Assert.assertEquals("<img alt=\"some alt text\" src=\"" + url + "\" width=\"100\" height=\"100\" />", img.asHtml(linkResolver));
   }
 


### PR DESCRIPTION
Hello Prismic team,

We've noticed a `NullPointerException` error which can occur when Prismic API returns an error with a body which does not contain the `error` json field.
The corresponding stracktrace:
```
java.lang.NullPointerException: null
    at io.prismic.core.HttpClient.fetch(HttpClient.java:62)
    at io.prismic.Form$SearchForm.submit(Form.java:411)
```

This PR handle this NPE and fix a test which fails since March 12th because of the default CDN activation.

Thanks!