### PR TITLE
docs: update the link for Beyond The API

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ Documentation for `prismicio/java-kit` is organized into the following sections.
 - [**Getting Started**](./01-getting-started.md)
 - [**Query the API**](./02-query-the-api)
 - [**Templating**](./03-templating)
-- [**Beyond the API**](./04-beyond-the-api)
+- [**Beyond the API**](./04-misc-topics)
 
 To learn more about [Prismic](https://prismic.io), including documentation for other languages and frameworks, see the main Prismic Documentation site.
 


### PR DESCRIPTION
The link on the readme was 404ing, looks like the directory name changed but the link wasn't updated to reflect the change.